### PR TITLE
Improved XCT* failure messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Pending
 
+- Improved error messaging with XCTAssert* calls. The main offender was when waiting for an element to be in a specific state and it would just show an error of `XCTAssertTrue failed`. (issue #80)
+
 ---
 
 ## 1.3.0

--- a/TABTestKit/Classes/Apps/BaseApp.swift
+++ b/TABTestKit/Classes/Apps/BaseApp.swift
@@ -18,29 +18,29 @@ open class BaseApp: XCUIApplication {
 	/// Launches the app, waiting for the state to be running before continuing.
 	override open func launch() {
 		super.launch()
-		XCTAssert(wait(for: .runningForeground, timeout: 60))
+		XCTAssertTrue(wait(for: .runningForeground, timeout: 60), "Failed waiting for app to become .runningForeground")
 	}
 	
 	/// "Backgrounds" the app, waiting for the state to be suspended before continuing.
 	open func background() {
 		XCUIDevice.shared.press(.home)
-		if #available(iOS 13.0, *) {
-			XCTAssert(wait(for: .runningBackground, timeout: 10))
+		if #available(iOS 13.0, *) { // https://github.com/theappbusiness/TABTestKit/issues/67
+			XCTAssertTrue(wait(for: .runningBackground, timeout: 10), "Failed waiting for app to become .runningBackground")
 		} else {
-			XCTAssert(wait(for: .runningBackgroundSuspended, timeout: 10))
+			XCTAssertTrue(wait(for: .runningBackgroundSuspended, timeout: 10), "Failed waiting for app to become .runningBackgroundSuspended")
 		}
 	}
 	
 	/// Activates/foregrounds the app, waiting for the state to be running before continuing.
 	override open func activate() {
 		super.activate()
-		XCTAssert(wait(for: .runningForeground, timeout: 10))
+		XCTAssertTrue(wait(for: .runningForeground, timeout: 10), "Failed waiting for app to become .runningForeground")
 	}
 	
 	/// Terminates the app, waiting for the state to be not running before continuing.
 	override open func terminate() {
 		super.terminate()
-		XCTAssert(wait(for: .notRunning, timeout: 10))
+		XCTAssertTrue(wait(for: .notRunning, timeout: 10), "Failed waiting for app to become .notRunning")
 	}
 	
 }

--- a/TABTestKit/Classes/Contexts/InteractionContext.swift
+++ b/TABTestKit/Classes/Contexts/InteractionContext.swift
@@ -38,7 +38,7 @@ public extension InteractionContext {
 				numberOfTries += 1
 				element.scroll(direction)
 			} while numberOfTries <= maxTries
-			XCTFail("Ran of out tries waiting for element to become \(state)")
+			XCTFail("Ran of out tries (\(maxTries)) waiting for element to become \(state)")
 		}
 	}
 	
@@ -50,7 +50,7 @@ public extension InteractionContext {
 				numberOfTries += 1
 				element.scroll(direction)
 			} while numberOfTries <= maxTries
-			XCTFail("Ran of out tries waiting for element to become not \(state)")
+			XCTFail("Ran of out tries (\(maxTries)) waiting for element to become not \(state)")
 		}
 	}
 	

--- a/TABTestKit/Classes/Contexts/KeyboardContext.swift
+++ b/TABTestKit/Classes/Contexts/KeyboardContext.swift
@@ -12,7 +12,8 @@ public protocol KeyboardContext {}
 public extension KeyboardContext {
 	
 	func keyboardType(is type: Keyboard.KeyboardType) {
-		XCTAssertEqual(type, TABTestKit.keyboard.keyboardType)
+		let actual = keyboard.keyboardType
+		XCTAssertEqual(type, actual, "Actual keyboard type (\(actual)) does not match expected keyboard type (\(type))")
 	}
 	
 }

--- a/TABTestKit/Classes/Elements/Switch.swift
+++ b/TABTestKit/Classes/Elements/Switch.swift
@@ -31,7 +31,7 @@ public struct Switch: Element, ValueRepresentable, Adjustable, Tappable {
 	public func adjust(to newValue: State) {
 		guard newValue != value else { XCTFatalFail("Switch is already in state \(newValue)") }
 		tap()
-		XCTAssert(underlyingXCUIElement.wait(for: newValue == value, timeout: 1))
+		XCTAssert(underlyingXCUIElement.wait(for: newValue == value, timeout: 1), "Failed waiting for Switch to have state \(newValue)")
 	}
 	
 }

--- a/TABTestKit/Classes/Protocols/Element.swift
+++ b/TABTestKit/Classes/Protocols/Element.swift
@@ -65,11 +65,11 @@ public extension Element {
 	/// You can provide multiple states, like `await(.exists, .hittable)`
 	///
 	/// - Parameter states: The states to wait for.
-	/// - Parameter timeout: The timout. Defaults to 30 seconds.
+	/// - Parameter timeout: The timeout. Defaults to 30 seconds.
 	func await(_ states: ElementAttributes.State..., timeout: TimeInterval = 30) {
 		guard !states.isEmpty else { XCTFatalFail("You must provide at least one state!") }
 		states.forEach { state in
-			XCTAssertTrue(determine(state, timeout: timeout))
+			XCTAssertTrue(determine(state, timeout: timeout), "Failed awaiting element to be \(state) with timeout \(timeout)")
 		}
 	}
 	
@@ -84,7 +84,7 @@ public extension Element {
 	func await(not states: ElementAttributes.State..., timeout: TimeInterval = 30) {
 		guard !states.isEmpty else { XCTFatalFail("You must provide at least one state!") }
 		states.forEach { state in
-			XCTAssertTrue(determine(not: state, timeout: timeout))
+			XCTAssertTrue(determine(not: state, timeout: timeout), "Failed awaiting element to not be \(state) with timeout \(timeout)")
 		}
 	}
 	


### PR DESCRIPTION
Following on from the last PR (#81) which hugely improves the way errors are reported on CI and in Xcode itself, this PR improves the actual messages themselves in many areas.