### PR TITLE
[Chore] Add page controller to example app with a test to be updated as part of issue 72

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language: swift
 os:
   - osx
 
-osx_image: xcode11.5
-env: IPHONE_SIMULATOR_SDK='iphonesimulator13.5' OS_VERSION='13.5' IPHONE_NAME='iPhone 11'
+osx_image: xcode10.3
+env: IPHONE_SIMULATOR_SDK='iphonesimulator12.4' OS_VERSION='12.4' IPHONE_NAME='iPhone Xs'
 
 addons:
   homebrew:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language: swift
 os:
   - osx
 
-osx_image: xcode10.3
-env: IPHONE_SIMULATOR_SDK='iphonesimulator12.4' OS_VERSION='12.4' IPHONE_NAME='iPhone Xs'
+osx_image: xcode11.5
+env: IPHONE_SIMULATOR_SDK='iphonesimulator13.5' OS_VERSION='13.5' IPHONE_NAME='iPhone 11'
 
 addons:
   homebrew:

--- a/Example/TABTestKit.xcodeproj/project.pbxproj
+++ b/Example/TABTestKit.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0C69DA1124B8A78D00E10F9E /* PageController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C69DA1024B8A78D00E10F9E /* PageController.swift */; };
+		0C69DA1324B8B7DC00E10F9E /* PageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C69DA1224B8B7DC00E10F9E /* PageTests.swift */; };
+		0C69DA1524B8B85500E10F9E /* PageScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C69DA1424B8B85500E10F9E /* PageScreen.swift */; };
 		607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD51AFB9204008FA782 /* AppDelegate.swift */; };
 		607FACDB1AFB9204008FA782 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 607FACD91AFB9204008FA782 /* Main.storyboard */; };
 		607FACDD1AFB9204008FA782 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDC1AFB9204008FA782 /* Images.xcassets */; };
@@ -48,6 +51,9 @@
 /* Begin PBXFileReference section */
 		0642FEC1D43A76605A007144 /* Pods_TABTestKit_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TABTestKit_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		0757BAFCD86952BF1F8792FB /* TABTestKit.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = TABTestKit.podspec; path = ../TABTestKit.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		0C69DA1024B8A78D00E10F9E /* PageController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageController.swift; sourceTree = "<group>"; };
+		0C69DA1224B8B7DC00E10F9E /* PageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageTests.swift; sourceTree = "<group>"; };
+		0C69DA1424B8B85500E10F9E /* PageScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageScreen.swift; sourceTree = "<group>"; };
 		0E196B5358EB5F29B443CE8E /* Pods_TABTestKit_Example_TABTestKit_ExampleUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TABTestKit_Example_TABTestKit_ExampleUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1CD6C67461B52B92ADDBB9FD /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
 		3275E3F4BE5C5BB1077B1015 /* Pods-TABTestKit_Example-TABTestKit_ExampleUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TABTestKit_Example-TABTestKit_ExampleUITests.release.xcconfig"; path = "Pods/Target Support Files/Pods-TABTestKit_Example-TABTestKit_ExampleUITests/Pods-TABTestKit_Example-TABTestKit_ExampleUITests.release.xcconfig"; sourceTree = "<group>"; };
@@ -157,6 +163,7 @@
 				C3DE8E462329037B007E583B /* TableSelectionController.swift */,
 				C368AF2E235095CC0015803A /* CollectionViewController.swift */,
 				C3DE8E4923291A34007E583B /* OtherElementsController.swift */,
+				0C69DA1024B8A78D00E10F9E /* PageController.swift */,
 				607FACD31AFB9204008FA782 /* Supporting Files */,
 			);
 			name = "Example for TABTestKit";
@@ -204,6 +211,7 @@
 				C3DE8E442328F646007E583B /* TableSelectionScreen.swift */,
 				C3DE8E4B232920F4007E583B /* OtherElementsScreen.swift */,
 				C3DE8E5E232A7564007E583B /* TabBarScreen.swift */,
+				0C69DA1424B8B85500E10F9E /* PageScreen.swift */,
 			);
 			name = Screens;
 			sourceTree = "<group>";
@@ -218,6 +226,7 @@
 				C368AF302350987D0015803A /* CollectionViewTests.swift */,
 				C3DE8E4D23293D4B007E583B /* OtherElementsTests.swift */,
 				C342580C2472A9F900B8E35C /* DeepLinkingTests.swift */,
+				0C69DA1224B8B7DC00E10F9E /* PageTests.swift */,
 			);
 			name = Tests;
 			sourceTree = "<group>";
@@ -432,6 +441,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0C69DA1124B8A78D00E10F9E /* PageController.swift in Sources */,
 				C326D660232788BA001AB082 /* BiometricLoginViewController.swift in Sources */,
 				607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */,
 				C326D6AD2327E8F7001AB082 /* TableController.swift in Sources */,
@@ -449,6 +459,7 @@
 				C326D6A62327DAA7001AB082 /* TableScreen.swift in Sources */,
 				C342580D2472A9F900B8E35C /* DeepLinkingTests.swift in Sources */,
 				C3DE8E4E23293D4B007E583B /* OtherElementsTests.swift in Sources */,
+				0C69DA1524B8B85500E10F9E /* PageScreen.swift in Sources */,
 				C3DE8E4C232920F4007E583B /* OtherElementsScreen.swift in Sources */,
 				C326D66623278E2E001AB082 /* BiometricLoginScreen.swift in Sources */,
 				C368AF33235098E70015803A /* CollectionViewScreen.swift in Sources */,
@@ -456,6 +467,7 @@
 				C368AF312350987D0015803A /* CollectionViewTests.swift in Sources */,
 				C326D6A82327DC15001AB082 /* BiometricLogin_PermissionDeniedTests.swift in Sources */,
 				C326D6AC2327E847001AB082 /* TableTests.swift in Sources */,
+				0C69DA1324B8B7DC00E10F9E /* PageTests.swift in Sources */,
 				C3DE8E452328F646007E583B /* TableSelectionScreen.swift in Sources */,
 				C326D6AA2327DFCC001AB082 /* BiometricLogin_AuthenticationFailureTests.swift in Sources */,
 				C3DE8E5F232A7564007E583B /* TabBarScreen.swift in Sources */,

--- a/Example/TABTestKit/Base.lproj/Main.storyboard
+++ b/Example/TABTestKit/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="VEl-fI-I9x">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="VEl-fI-I9x">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -22,11 +22,12 @@
                         <segue destination="CZc-fh-uXm" kind="relationship" relationship="viewControllers" id="M6Y-7w-ha8"/>
                         <segue destination="3uD-U6-zpv" kind="presentation" identifier="BiometricLoginViewController" modalPresentationStyle="fullScreen" id="1Wd-wC-qnx"/>
                         <segue destination="EeR-CP-KFI" kind="relationship" relationship="viewControllers" id="J8z-aD-RBA"/>
+                        <segue destination="2OA-Nv-LiK" kind="relationship" relationship="viewControllers" id="Gz7-rf-bxg"/>
                     </connections>
                 </tabBarController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="lab-gg-Ww4" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-26" y="-652"/>
+            <point key="canvasLocation" x="-212" y="585"/>
         </scene>
         <!--Table-->
         <scene sceneID="anu-hn-M2Y">
@@ -136,6 +137,16 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="6qD-RO-mUT" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="1121" y="876"/>
+        </scene>
+        <!--Page-->
+        <scene sceneID="c0y-gk-Doa">
+            <objects>
+                <pageViewController autoresizesArchivedViewToFullSize="NO" transitionStyle="scroll" navigationOrientation="horizontal" spineLocation="none" id="ugK-Fe-gyT" customClass="PageController" customModule="TABTestKit_Example" customModuleProvider="target" sceneMemberID="viewController">
+                    <navigationItem key="navigationItem" title="Page" id="wto-5H-nHP"/>
+                </pageViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="y6J-sR-xU5" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2060" y="1573"/>
         </scene>
         <!--Other elements-->
         <scene sceneID="3aC-WN-Fc9">
@@ -404,7 +415,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="8FK-ee-gsS" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-26" y="137"/>
+            <point key="canvasLocation" x="-212" y="1441"/>
         </scene>
         <!--Collection-->
         <scene sceneID="9Px-jB-nTh">
@@ -424,6 +435,25 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="9Et-tq-h0g" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="1120.8" y="137.18140929535232"/>
+        </scene>
+        <!--Page-->
+        <scene sceneID="AdW-ZX-mv4">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="2OA-Nv-LiK" sceneMemberID="viewController">
+                    <tabBarItem key="tabBarItem" title="Page" id="NjX-TZ-cBr"/>
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="tmb-VQ-1f1">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="ugK-Fe-gyT" kind="relationship" relationship="rootViewController" id="PsZ-n0-WV8"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="9AE-8a-pgz" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1121" y="1573"/>
         </scene>
     </scenes>
 </document>

--- a/Example/TABTestKit/PageController.swift
+++ b/Example/TABTestKit/PageController.swift
@@ -1,0 +1,67 @@
+//
+//  PageController.swift
+//  TABTestKit_Example
+//
+//  Created by Ben Gilroy on 10/07/2020.
+//  Copyright © 2020 The App Business LTD. All rights reserved.
+//
+
+import UIKit
+
+final class PageController: UIPageViewController {
+    
+    private var pages: [UIViewController] = []
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .white
+        view.accessibilityIdentifier = "PageView"
+        setupPages()
+        setupPageControl()
+        dataSource = self
+    }
+    
+    private func setupPages() {
+        let colors: [UIColor] = [.red, .orange, .yellow, .green, .blue, .purple]
+        pages = colors.map { color in
+            let viewController = UIViewController()
+            viewController.view.backgroundColor = color
+            return viewController
+        }
+        setViewControllers([pages[0]], direction: .forward, animated: false)
+    }
+    
+    private func setupPageControl() {
+        let appearance = UIPageControl.appearance()
+        appearance.pageIndicatorTintColor = .gray
+        appearance.currentPageIndicatorTintColor = .black
+        appearance.backgroundColor = .white
+    }
+
+}
+
+extension PageController: UIPageViewControllerDataSource {
+    
+    func pageViewController(_ pageViewController: UIPageViewController, viewControllerBefore viewController: UIViewController) -> UIViewController? {
+        guard let currentIndex = pages.firstIndex(of: viewController), currentIndex > 0 else {
+            return nil
+        }
+        return pages[currentIndex - 1]
+    }
+    
+    func pageViewController(_ pageViewController: UIPageViewController, viewControllerAfter viewController: UIViewController) -> UIViewController? {
+        guard let currentIndex = pages.firstIndex(of: viewController), currentIndex < pages.count - 1 else {
+            return nil
+        }
+        return pages[currentIndex + 1]
+    }
+    
+    func presentationCount(for pageViewController: UIPageViewController) -> Int {
+        return pages.count
+    }
+    
+    func presentationIndex(for pageViewController: UIPageViewController) -> Int {
+        return 0
+    }
+    
+}

--- a/Example/TABTestKit_ExampleUITests/PageScreen.swift
+++ b/Example/TABTestKit_ExampleUITests/PageScreen.swift
@@ -1,0 +1,20 @@
+//
+//  PageScreen.swift
+//  TABTestKit_ExampleUITests
+//
+//  Created by Ben Gilroy on 10/07/2020.
+//  Copyright © 2020 The App Business LTD. All rights reserved.
+//
+
+import TABTestKit
+
+let pageScreen = PageScreen()
+
+struct PageScreen: Screen {
+  
+    var trait: View { return view }
+    let view = View(id: "PageView")
+    var scrollView: ScrollView { ScrollView(parent: view) }
+    var pageIndicator: PageIndicator { PageIndicator(parent: view) }
+
+}

--- a/Example/TABTestKit_ExampleUITests/PageScreen.swift
+++ b/Example/TABTestKit_ExampleUITests/PageScreen.swift
@@ -14,7 +14,7 @@ struct PageScreen: Screen {
   
     var trait: View { return view }
     let view = View(id: "PageView")
-    var scrollView: ScrollView { ScrollView(parent: view) }
-    var pageIndicator: PageIndicator { PageIndicator(parent: view) }
+    var scrollView: ScrollView { return ScrollView(parent: view) }
+    var pageIndicator: PageIndicator { return PageIndicator(parent: view) }
 
 }

--- a/Example/TABTestKit_ExampleUITests/PageTests.swift
+++ b/Example/TABTestKit_ExampleUITests/PageTests.swift
@@ -15,8 +15,6 @@ final class PageTests: TABTestCase {
             Given(I: complete(biometricLoginScreen))
             And(I: see(tabBarScreen))
             When(I: tap(tabBarScreen.pageTabBarButton))
-            sleep(1)
-            print(App.shared.debugDescription)
             Then(I: see(pageScreen))
         }
         

--- a/Example/TABTestKit_ExampleUITests/PageTests.swift
+++ b/Example/TABTestKit_ExampleUITests/PageTests.swift
@@ -1,0 +1,35 @@
+//
+//  PageTests.swift
+//  TABTestKit_ExampleUITests
+//
+//  Created by Ben Gilroy on 10/07/2020.
+//  Copyright © 2020 The App Business LTD. All rights reserved.
+//
+
+import TABTestKit
+
+final class PageTests: TABTestCase {
+
+    func test() {
+        Scenario("Navigate to page view") {
+            Given(I: complete(biometricLoginScreen))
+            And(I: see(tabBarScreen))
+            When(I: tap(tabBarScreen.pageTabBarButton))
+            sleep(1)
+            print(App.shared.debugDescription)
+            Then(I: see(pageScreen))
+        }
+        
+        // TODO: Replace with 'scroll until value of X is Y' as part of https://github.com/theappbusiness/TABTestKit/issues/72
+        Scenario("Scroll page view") {
+            Given(I: see(pageScreen))
+            When(I: pageScreen.scrollView.scroll(.right))
+            And(I: pageScreen.scrollView.scroll(.right))
+            And(I: pageScreen.scrollView.scroll(.right))
+            And(I: pageScreen.scrollView.scroll(.right))
+            And(I: pageScreen.scrollView.scroll(.right))
+            Then(the: value(of: pageScreen.pageIndicator, is: "page 6 of 6"))
+        }
+    }
+
+}

--- a/Example/TABTestKit_ExampleUITests/PageTests.swift
+++ b/Example/TABTestKit_ExampleUITests/PageTests.swift
@@ -11,6 +11,12 @@ import TABTestKit
 final class PageTests: TABTestCase {
 
     func test() {
+        // This test will fail on iOS 12 as the scroll view in UIPageViewController
+        // does not have the accessibility trait of scroll view. This has been fixed
+        // in iOS 13. When iOS 12 support is dropped, this check can be removed.
+        guard #available(iOS 13, *) else {
+            return
+        }
         Scenario("Navigate to page view") {
             Given(I: complete(biometricLoginScreen))
             And(I: see(tabBarScreen))

--- a/Example/TABTestKit_ExampleUITests/TabBarScreen.swift
+++ b/Example/TABTestKit_ExampleUITests/TabBarScreen.swift
@@ -23,5 +23,8 @@ struct TabBarScreen: Screen {
   var otherTabBarButton: Button {
     return tabBar.button(withID: "Other")
   }
+  var pageTabBarButton: Button {
+    return tabBar.button(withID: "Page")
+  }
   
 }


### PR DESCRIPTION
@annapiktas is working on #72 but there is no way to currently test a working solution in the app.

This PR adds a simple page view controller to the example app with a corresponding test that can be updated once the work for #72 is updated.

Note: This involves no functional change to TABTestKit itself, just the example app and its tests.