### PR TITLE
Supports DatePicker element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 - Added support for double tapping, long pressing and two finger tapping, with default implementations for any Elements that conform to Tappable. (issue #88)
 - Configured Travis to build and test on multiple Xcodes
 - Added Swift Package Manager support
--  Added a `Refreshable` protocol so for each element/screen that conforms to protocol `refresh` function can be defined 
+- Added a `Refreshable` protocol so for each element/screen that conforms to protocol `refresh` function can be defined 
+- Added a `DatePicker` element. (issue #55)
 
 ---
 

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -7,228 +7,230 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		057AD19E80F1F6E17D80CDC554C0E41F /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2C061463250766C9C05995AB8EE63E66 /* XCTest.framework */; };
-		07FDD88F73EA8960D0F9E3C3EF4B6E4E /* Button.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BFD6C0764CD43FFB743CE603C9FFD68 /* Button.swift */; };
-		0B68E89B98365D41A7600239B2092EDD /* Picker.swift in Sources */ = {isa = PBXBuildFile; fileRef = D07C967D9F11E4E64FCCB0515B63C928 /* Picker.swift */; };
-		0D0CA421CAB8CFB002F3A7958428F87D /* Sheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FDC2516655ADE505B015B6C694D2328 /* Sheet.swift */; };
-		1090D87A7D515D6D41D894DD759E7A5F /* Table.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9089417F0109865CDB124A2329BDD6FB /* Table.swift */; };
-		11661C36C0918639523AE19766D96ADB /* Springboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2ACC1384856F32BDEAF0B67C4ABBA6 /* Springboard.swift */; };
-		182CC29C7BAFE0334AC07728900F1D6C /* Pods-TABTestKit_Example-TABTestKit_ExampleUITests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 99E06D4FF45A3B2605A88BF7D8DDC1C9 /* Pods-TABTestKit_Example-TABTestKit_ExampleUITests-dummy.m */; };
-		1B1415B0B3DB73411748BF869920A0F2 /* TABTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B5CC92563CE4BC7DA55A6394BD6A1DA /* TABTestCase.swift */; };
-		1C9C381CC36794C97A0D5856A243AECA /* Completable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E69262C4F4A355BF4676D44D72262A23 /* Completable.swift */; };
-		1CAD5E52058606696556F9E164DC8D5D /* SegmentedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2120EE906455FB83E2E09406CEF662C9 /* SegmentedControl.swift */; };
-		208D7E4CF6D5816E2375BD8E79E45004 /* Tappable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06062B1405E6248957F1FA51ED99AEAE /* Tappable.swift */; };
-		23FED18C864803B6CD493F0DED90E82B /* Slider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71BC30DBECCC085046C14F79A51C96FC /* Slider.swift */; };
+		030C8476D8BE89065E5328E67EF56752 /* DatePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A869D57AC8EDD0ED0BC6DA6BD96660 /* DatePicker.swift */; };
+		037438E458F376D3ED3311C9C9C424D1 /* ActivitySheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF3CF5B9ABEEA0EDC977AFA1D3653700 /* ActivitySheet.swift */; };
+		06F0BA93FE06A8B562D3D88F82D1FF43 /* Biometrics-Bridging-Header.h in Headers */ = {isa = PBXBuildFile; fileRef = 76351B41B9C4CCADF915B35D11C74EAC /* Biometrics-Bridging-Header.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		073BB799FC643900737132A1DAC712C1 /* Editable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5D608343740CFA224AF053B57F66F67 /* Editable.swift */; };
+		074443E7511027A2E5ED3909C0EA4C9B /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 033A36A29482FD32230FE0CA177F9BD3 /* Foundation.framework */; };
+		0E61D42891FE5FEC32F4F79B64A0A31A /* SystemPreferencesContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = C886680EDE8E68E288F0B0967127256D /* SystemPreferencesContext.swift */; };
+		11278B65581A09C350D0FE282C241B2F /* SegmentedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B82B2F93A1BE5B4C63A8A4CB66E2BE9 /* SegmentedControl.swift */; };
+		145EF16BC9E3275A3BE2EA2E24CCC25B /* SystemPreferencesResetScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A5843633E4D75EE8E1556F939DB746 /* SystemPreferencesResetScreen.swift */; };
+		1769E66936A8148901759A505D1134D8 /* Screen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EECF51F8060F5B8BFA4281A38586E83 /* Screen.swift */; };
+		178C0B2157C033E8875D33BAFCCD1A07 /* Pods-TABTestKit_Example-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 28061D8B4A5060F09E692D4BC586713B /* Pods-TABTestKit_Example-dummy.m */; };
+		1CF73984D3297083B164E8AFDFB68A9D /* KeyboardContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = B34195E62CE6D4325A0363AF69BD0FB9 /* KeyboardContext.swift */; };
+		1EEECE824542B4516057559E98B80E1C /* Alert.swift in Sources */ = {isa = PBXBuildFile; fileRef = E59DB98EC39EB118496B12CB4BE9C95C /* Alert.swift */; };
+		1F4FEC3156C65D28F6B9458BD75E2F88 /* NavigationContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2F76C444323B6EB045D04A8CE4B6F18 /* NavigationContext.swift */; };
+		1FDB0E9D01FF2441B2C4BFDB3367E927 /* Button.swift in Sources */ = {isa = PBXBuildFile; fileRef = B906394D23C1F041CA4124C3B1FFF2F3 /* Button.swift */; };
+		205F7DF3026977DA94FAC59A3D0B9F32 /* InteractionContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = D91666C6805484361A8042FE298F3C08 /* InteractionContext.swift */; };
+		214C5AC2BEB372773B81A89E3CA9649E /* systemPreferencesRootScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8D0C69508B528128406927836573B67 /* systemPreferencesRootScreen.swift */; };
+		22824B0B33B4C8170ED1DE4ABC96A61A /* XCUIDevice+frame.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5109E1F024CAEEB532DC9DC19512FF1 /* XCUIDevice+frame.swift */; };
+		22AB496E63075EE106F9BA6B4D5CA93A /* Biometrics.h in Headers */ = {isa = PBXBuildFile; fileRef = FBA47936DBE7936C98F0EC94B9E8CEAC /* Biometrics.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		232838548112A58B1405F1649A3C8D5A /* Switch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 833F3150E7163B9CDD9DC3F6667D24AE /* Switch.swift */; };
+		24D51ED262D69888D4892E35D4B296B1 /* App.swift in Sources */ = {isa = PBXBuildFile; fileRef = D633AFB6915D96D516CD0872E60E2415 /* App.swift */; };
+		25CB8336A1F82DDC9CD5005EFBB7F29B /* Icon.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99BC68F60289EE3D2B827C55151ED07 /* Icon.swift */; };
 		267805C828A9D1D94D9CACAE5C603CDD /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 033A36A29482FD32230FE0CA177F9BD3 /* Foundation.framework */; };
 		27CB0A5EB157C02C3FDFCC594331324E /* ShowTime-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 69152FFA4489AC24B45BCE5208B3B41A /* ShowTime-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		280DE7E704E54040AAD99A912D804B1C /* XCUIElement+wait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D9D28DCEEADE9294B60676002E5F3AF /* XCUIElement+wait.swift */; };
-		28C2F366D4A968DBCF276D13CF9EF6CF /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 033A36A29482FD32230FE0CA177F9BD3 /* Foundation.framework */; };
-		2A7568FFE5FC98F3A8A8C9EC2E6CFBBA /* SecureTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539E3535E6A4796A5DC1359080B1B388 /* SecureTextField.swift */; };
-		31D832E6B1905EB24BD3914FB9E4E26D /* Adjustable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4168F73CEF3298398FAFE1F3755C496 /* Adjustable.swift */; };
-		31E317402DD57DCD01147DD5A1B03793 /* Scenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = D62EEF2B33953AEF764BCFFC3597CF30 /* Scenario.swift */; };
-		320CD0432837527FF659853E14CCE0EB /* Editable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 233D9F6DE5B7ED9B213DDEE7A60DF4D2 /* Editable.swift */; };
+		297A89E5D9EA42B0F082560478BD138D /* ScrollableScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D132E7F63ED7978B99EF4975197150F /* ScrollableScreen.swift */; };
+		33A0126A9943D162EDCC4DE493D8A168 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2C061463250766C9C05995AB8EE63E66 /* XCTest.framework */; };
 		3C892CB7517172243FF2DA110515208C /* ShowTime-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = F094F44DD0301CC76E1365673D3FCF9C /* ShowTime-dummy.m */; };
-		3FFB5CEAF0482B2CC8FA486FAFE32A62 /* Header.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6980B17C7DE4DADEAE4CC75D703C54AC /* Header.swift */; };
-		4101E143EB6E39F850E73276237625DD /* TextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A44D97A79485D765FFC1885EF486035C /* TextView.swift */; };
-		430AC0E3784C452CA9A861D9E6AC9E46 /* BiometricsContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ABBEEBD584246EF61D103CF1C923A0E /* BiometricsContext.swift */; };
-		4B8A6E15476B0C9F6CBC5F274DE4FC7C /* CellContaining.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FD98E1ABC6B6C0E1972A84DF17C5101 /* CellContaining.swift */; };
-		57001A8096851FD8002D6A76EE216715 /* ScrollableScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029ACEB452A14FC499201FC3B0C4ED34 /* ScrollableScreen.swift */; };
-		57ED8608C9256BFEE6338B4D9C6BA3D2 /* SystemPreferencesResetScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D9B3886BA63D85E95DC7C0E2C41C9C9 /* SystemPreferencesResetScreen.swift */; };
-		58810327410B85FEB119763254AA4B0B /* BaseApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6FEDCB8E835BAD94013EC96B36228F2 /* BaseApp.swift */; };
-		59C61F9D86B646893D50711CC5C6801A /* NavigationContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48F3EF5E147F848C915D2D095DFA422D /* NavigationContext.swift */; };
-		5B39540A604873FB3180D8B28B8B88FA /* XCUIElement+hasKeyboardFocus.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD112D38CB4A7946791170C90730CC9D /* XCUIElement+hasKeyboardFocus.swift */; };
-		5D7A82AD1AFEF42A0E95D96C466A99E6 /* Attributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E4EAF339F88D5CC4828E58D2D044BA /* Attributes.swift */; };
-		63D3C37B825C72FC8B554ECEF6A1C189 /* View.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB73F3D5CE27BEFC135A72853A578770 /* View.swift */; };
-		63EA29EA99DA5C624B186F7CD629B14D /* XCTFatalFail.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBE7A8817DB54096950BC6C6163FB2C0 /* XCTFatalFail.swift */; };
-		64014F0876F2797A9BA0548CF916D20B /* PageIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BF44A3860DAFA6F569C7C830A6F42C2 /* PageIndicator.swift */; };
-		64BAD1DD1EA45B92B9AFF98CE73A5ED4 /* Alert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63808F52E6B612D9117EA7F81237AAED /* Alert.swift */; };
-		6972944BAF55F67D1613B40566B51B59 /* AlertContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58701D6FE5B0819E5ECE654224188DC0 /* AlertContext.swift */; };
-		6976C71365844907D1C897F35DF571C4 /* CGVector+Offset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 238D94DB52E866485358E8A0DB1C35AF /* CGVector+Offset.swift */; };
-		6E077301C2429F6C0F506EC83BFCDCB3 /* NavBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71AC18C8449F986EBB02832E2A07A50F /* NavBar.swift */; };
-		743F40249F12DD773D943A66974214F9 /* NormalizedCoordinate+Locations.swift in Sources */ = {isa = PBXBuildFile; fileRef = E78108E38AC455729C36C4C7EEDE146C /* NormalizedCoordinate+Locations.swift */; };
-		747122308EDDFEF93EF4E728E15CF1F6 /* TABTestKit-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 987BEA52658B9CB88A6F751D324F13AD /* TABTestKit-dummy.m */; };
-		74E2F7EA36D277B32C6F922F069AD086 /* Pods-TABTestKit_Example-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 9FEFF9CD73B2D6723ED60BBDD46577CD /* Pods-TABTestKit_Example-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		795BE4C0034613920A5C128A01BB53C7 /* TABTestKit-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = F00418B0925C8A96D09D1986BE6C1B6B /* TABTestKit-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7BE3CA364825F8CD761A911CA29DEC00 /* ActivitySheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC8682021049AEAAB3DCD7C150A95FB2 /* ActivitySheet.swift */; };
-		7E7556B81F678C3A6E6580D9039C676A /* Pods-TABTestKit_Example-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 28061D8B4A5060F09E692D4BC586713B /* Pods-TABTestKit_Example-dummy.m */; };
-		7FC59073193FDD929E3C7DF6C5F7DAC8 /* Step.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82E2D18AF412B9ED1E41630009454979 /* Step.swift */; };
-		80A3AB6B2D68A0FE6AD65D9E406C0610 /* Scrollable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F91B925F791557160A72CB6C0BA49D45 /* Scrollable.swift */; };
-		84207533D404FF5E0399A8E25C9E54B1 /* SystemPreferencesGeneralScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA36B114B42B335BCF6F8F96ED83733E /* SystemPreferencesGeneralScreen.swift */; };
-		859F328E4ABF338A9987E4A2A835B5D2 /* Stepper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E675701574C76D0C286A4F6FFFFB5E5 /* Stepper.swift */; };
-		863EE3A68BBD9D64B35BD86403CFE347 /* AppContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E21D12E79B060EEABD6D9C064FD58DC /* AppContext.swift */; };
-		87219A0833E2C2DB62240B62D31BCB17 /* KeyboardContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9428A8F167FEB42DE18A7EBD813A80A5 /* KeyboardContext.swift */; };
-		8927BD966BA8175BBCD4A4C1E98EC03C /* Pods-TABTestKit_Example-TABTestKit_ExampleUITests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = C6AFBB671D10E6AEF0786D8E3E16BDE4 /* Pods-TABTestKit_Example-TABTestKit_ExampleUITests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8BB6FAEAAE345666BA4D0339B6512DA6 /* Image.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0A11CCC52D92B046F8A9FA9AC99AF4F /* Image.swift */; };
-		930BB84CB3CD91D6C3F47344F1E3B716 /* Dismissable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1535CFEC7782CBF5925C8C4087599AF0 /* Dismissable.swift */; };
-		96F4D54DC6D19C2B62038FB29CA14EFC /* Switch.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4F037B014CEDE4C8F4E39CB25E05DD2 /* Switch.swift */; };
-		9BB4E051EA402E2BFC9EC5D111B197FF /* Label.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34B6C40BC468C579D69B2CC4CAF320EC /* Label.swift */; };
-		A0CB99B9EA85274E99D1FA593199CFE0 /* ValueRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC8E6BB8E22FC1B0C1930A4F8B678E92 /* ValueRepresentable.swift */; };
-		A1DEEA086571A976344EACF308E8B05C /* Element+defaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD37B9C8E065DD3D17F7204B1B1FBD58 /* Element+defaults.swift */; };
-		A3D01C0F1E1F3BD46CBE767C7A2BD535 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 033A36A29482FD32230FE0CA177F9BD3 /* Foundation.framework */; };
-		A42C4B780986976455B79A6DCE9DA9E2 /* systemPreferencesRootScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AEC6A3A9A1E90D3C5F4B4A736C8E946 /* systemPreferencesRootScreen.swift */; };
-		A491165E101133259FF943950187B759 /* SheetContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 609F80835D951294E6054EC34BE7DEAB /* SheetContext.swift */; };
-		AE85E79E4A1CB7C55A422C5B8095547F /* Biometrics.m in Sources */ = {isa = PBXBuildFile; fileRef = BA5720DEDCE2EE95A4B4F67D967D49EE /* Biometrics.m */; };
-		B36FC689297C3EE65EB22BA68CD71863 /* Refreshable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44F9BE5C5077780745214E80112EF7EF /* Refreshable.swift */; };
-		B37EC5CB2875EB4529A536911F8660EE /* Cell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EE536BF6DFF2331078DBAADAAB49035 /* Cell.swift */; };
-		B4C82C8ACF0F022053310C472E055B93 /* TextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 428C7E1FA710CF3CFD6B1D091E8DA215 /* TextField.swift */; };
-		B513DE81DB5A4FF5CB34A166242B6A1B /* App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17DCECBA4EAAE4C07053D26FBE892D78 /* App.swift */; };
-		B689E311677718EBC18E8A65181E28D1 /* CollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A6FE0B2CF948C41E54AA50B9A2DBFE6 /* CollectionView.swift */; };
-		B7CF969CE6C43590EF1C83A67707912A /* ScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EB66BEA4359AD0F6E58CE8E61A7D651 /* ScrollView.swift */; };
+		3D53EE53A9983C943A862D0383369B25 /* Pods-TABTestKit_Example-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 9FEFF9CD73B2D6723ED60BBDD46577CD /* Pods-TABTestKit_Example-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3DDA18D51471D4B5A53CA30FB7A4800E /* TABTestKit-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 39F10CDF64864F18B3EEAAE5618F2993 /* TABTestKit-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		466B4F15E513602A12E004EE0DDC43EE /* Pods-TABTestKit_Example-TABTestKit_ExampleUITests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = C6AFBB671D10E6AEF0786D8E3E16BDE4 /* Pods-TABTestKit_Example-TABTestKit_ExampleUITests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		481F82DB88069C6B92FF1778580B39F6 /* Slider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97B6600289CF1454BB2B7A95FE5523AB /* Slider.swift */; };
+		4CF2489EF04BC5D95D8CC7B883F8F136 /* SystemPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4508197147D357E5AC5F92B14089EC1 /* SystemPreferences.swift */; };
+		4D991C4CAEF57EB28E0F107BCBCC5464 /* XCUIElement+wait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58185D0DA6046583EA0F3992B136C18F /* XCUIElement+wait.swift */; };
+		4DF904622DBED25D617FB92185ACCAF7 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 033A36A29482FD32230FE0CA177F9BD3 /* Foundation.framework */; };
+		56D50EAF7965D5AE0E5181A61398C2FE /* CellContaining.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDF4947C9E27BB97B30F06939F64E9E0 /* CellContaining.swift */; };
+		6693CC10486D411C5AEE771A4DED0AB4 /* Tappable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E846D1B6D74DE542E5CA9527BD39F15F /* Tappable.swift */; };
+		672CCDA6A5E3879637348218DCC4A967 /* BiometricsContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = A361D13461D8EC6C08FFF31BDF8D1806 /* BiometricsContext.swift */; };
+		67BDAF48BC71ADD6FFBD9BC3F60CC489 /* Attributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13B5D2EB83CCADFD7A1E0058D8A2B609 /* Attributes.swift */; };
+		697DDFCEB90BB157DB000D322CD19D5C /* PageIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1146247962F18FFC769B180EB17B0A5D /* PageIndicator.swift */; };
+		6BEE0D6E2E2AB96DD64F04F9B4C33B2D /* Header.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EFFE450A2ED2E1A13F6291EF95C4F19 /* Header.swift */; };
+		6D14253BA9582C897106391DA95677C5 /* Dismissable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3EE8B1C53D5F26ACBFF010AEABAE28B /* Dismissable.swift */; };
+		6FB96E7AE7560CFFE96A83D5A2B9FFC9 /* WebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8889DDD0297F197C953F944C127449C /* WebView.swift */; };
+		707000A4026440BF85F559F095DEB890 /* Completable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 733C9EB16F7A1DF6E9E333F54B511D02 /* Completable.swift */; };
+		723BE432EFB0A62753F492943A3A67B4 /* TABTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9017D3505D12281FD18FE6120B0A5DE /* TABTestCase.swift */; };
+		74FE7D271C05B5F5CF16CD40289ED053 /* NavBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31BB533F397C5D4FD9F1F0910B521877 /* NavBar.swift */; };
+		7E50C1883D363FEBF04C6B1F0D12E834 /* Cell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B0AB1F764B8B3C263215AFEFC01143A /* Cell.swift */; };
+		7FF9CA487AB366CCB8F77DD7B22AB8F4 /* Sheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 270FD9B498764D8FEA3F42DB3007EE80 /* Sheet.swift */; };
+		84B1885DB2D83AFD090C3CCCA8472C4E /* CollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DB84493C64353132E6F27571A43A3F6 /* CollectionView.swift */; };
+		8722F7FE01B09905CE43F5FE2F84E4AB /* Table.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0930640B9F785B2533E020EBE1A83252 /* Table.swift */; };
+		94D870EB04EAD571F26204DFA1DE5BF8 /* Adjustable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E1A9256A8DD33C89BAAB57A235F2804 /* Adjustable.swift */; };
+		965F572E8A4577F5564E718B08CA0DEC /* AppContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = B62E07EF0C9BE6DEF51F0BE719EFEB9E /* AppContext.swift */; };
+		96CF87699933D48A91FDD92BBBBD3A96 /* SystemPreferencesGeneralScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFE83F853FC56745500A916FBFE0BD09 /* SystemPreferencesGeneralScreen.swift */; };
+		981319D676A5ECFF485A539211C464A2 /* ScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3B5FEA5DCDCA2D582C00DE6B76CDC0B /* ScrollView.swift */; };
+		9914EC8EA7D7B376F4F8046D2F5A8380 /* XCUIElement+isVisible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00B178BBB394C26212D58AE9F1A3376E /* XCUIElement+isVisible.swift */; };
+		9D1D06B968FEF34BEFBC5DA3B5F211A3 /* XCTFatalFail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28FC2FFEC625B0FA3CD74A1DA0360038 /* XCTFatalFail.swift */; };
+		A41B5CCF42789157090E258FE089586C /* Element.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99645CE216E89A6655EC66E732CECD38 /* Element.swift */; };
+		AE182ECBB0181991D6E601FF083869A3 /* SheetContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2E454FE7393A49B62A15ECF95C55AF /* SheetContext.swift */; };
+		B169B20C039E782186565E2E52ACB787 /* AlertContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44D3D373915DB3F443D51C091A399226 /* AlertContext.swift */; };
+		B355BFBF02732C2EFDFCC79CE84DBEEF /* Picker.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F3ADBAFBD856493872E3528629CE26 /* Picker.swift */; };
+		B390F02F5BF0E704C2530E6B864C8DA4 /* TabBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 525F300EF39DA23BCE9573EFDF316426 /* TabBar.swift */; };
+		B3F91A927D31FD30CAE8C721D3CDD916 /* Scrollable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F2A3A2A26E9B32CC1F97EE09E1F276 /* Scrollable.swift */; };
+		B958E7CE0D4615F3F9D93D4E33F4DF36 /* TABTestKit-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 76218D3926FC14AD26D4F85F24A78116 /* TABTestKit-dummy.m */; };
 		BA42C86F6872AC87ADF7110F65920109 /* ShowTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAF2F2B8E583A5D847949453BAC20C6B /* ShowTime.swift */; };
-		BB77F7A6807B6E204739EB0881E3B4CA /* Icon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 288348B0E48E8832F351BC7B63303777 /* Icon.swift */; };
-		BC63BDE0255954A2DA44B3F1D90E30D1 /* XCUIDevice+frame.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F71C696D13A19D07E5810318AA9384 /* XCUIDevice+frame.swift */; };
-		BD175ABDA60A025E76859EC888C936CB /* SystemPreferencesContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20F6759CD9CFC4C1F5DA6B78EFFBB609 /* SystemPreferencesContext.swift */; };
-		C5CD0C3F1C611A6F4C44A5752E91C2F5 /* InteractionContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = E34A4D0E90CA84F5B686ECC33E84720D /* InteractionContext.swift */; };
-		C997CEF610E3041E1C3A5E95D08932B7 /* Screen.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB18014FAD1F5EE5FA9E004624623989 /* Screen.swift */; };
-		D0A0967C43C505030195B253B82C5E33 /* Biometrics-Bridging-Header.h in Headers */ = {isa = PBXBuildFile; fileRef = 825F5BBC95C9AD5A6FEF97516F438976 /* Biometrics-Bridging-Header.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D0FD68BBEC62BB6F4DB4D2F58E269A44 /* XCUIElement+isVisible.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC56A10DF2C24631522AEF8CBF30B351 /* XCUIElement+isVisible.swift */; };
-		D9D0A3DCC7BEB64B8F1602523BA266E4 /* SystemPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2ADFBF8A19DAC2594ED4548F1696E8C9 /* SystemPreferences.swift */; };
-		DB455946D47F73E2186787172F680213 /* Element.swift in Sources */ = {isa = PBXBuildFile; fileRef = 526C28167B8EB919F428D251486F18A3 /* Element.swift */; };
-		DCBC7977519A09E364F903C059F52EBF /* Biometrics.h in Headers */ = {isa = PBXBuildFile; fileRef = 801D065A67CFE384AC907A0A08A80669 /* Biometrics.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E434A53EF6A44B1AE884F2B627B29B32 /* TabBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A139CE57C53F627624E7B2244D19E74 /* TabBar.swift */; };
-		E7FB14F2DBF5C8E23887E8D7E4D0FA33 /* Safari.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10C6E6AABDEF73C8D9E647494F5FFFD /* Safari.swift */; };
-		EA26D3491AF4F16202B2F0B5A231CCD8 /* Array+Safe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E78188EC60ABEC11AE165500D2CFFCB /* Array+Safe.swift */; };
-		F259DC0C2C71FE4DE5FAAD5C376C0601 /* Keyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37CD9BB357BD4C98594C6FDB2372E203 /* Keyboard.swift */; };
-		F9323849E50840C3CC8D3EA197513D5E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 033A36A29482FD32230FE0CA177F9BD3 /* Foundation.framework */; };
-		FDA563324A4D72C0C284BEF9380A869C /* WebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30B66790D2082BEC84983A6EF4BF5662 /* WebView.swift */; };
+		C28393A7BA4949E7EC11BA68290E0A89 /* Biometrics.m in Sources */ = {isa = PBXBuildFile; fileRef = 516FEC36F601143A1A7D9C4483043E02 /* Biometrics.m */; };
+		C45F1CA24939CFC0EA011576B184E517 /* BaseApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 063860976CBFED0CEABD0E3213F93A8E /* BaseApp.swift */; };
+		C5E46852D59375EE4308956FD7ACADE6 /* TextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E96D37C7B544B5D3F8FABFDB3A65DFD /* TextField.swift */; };
+		C9939C0BDAD41AA1F33BE52342C396FB /* Refreshable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C38F549CCB18E20A90695795AEC5AC6 /* Refreshable.swift */; };
+		CE96ADAED2FDB8BB47A327A08562475C /* SecureTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E0C2DB87953FDF97B668A8BE0A744E /* SecureTextField.swift */; };
+		D83B7250A5C7CDFE4F64E0EEDD639892 /* Safari.swift in Sources */ = {isa = PBXBuildFile; fileRef = 378BEB1C3B86DE939F26118388E95363 /* Safari.swift */; };
+		D86774E04E3EAF51A19C123A7D21000A /* XCUIElement+hasKeyboardFocus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2729792DB920A36618545DE30B46AA58 /* XCUIElement+hasKeyboardFocus.swift */; };
+		D8771E317705B1A18BFDE9E3C391EF7F /* Step.swift in Sources */ = {isa = PBXBuildFile; fileRef = B16CB0412D2D22CA01914F6BAE91169D /* Step.swift */; };
+		DA63C2BDCDFB0A29EF5D49EDF95724BF /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 033A36A29482FD32230FE0CA177F9BD3 /* Foundation.framework */; };
+		DA63CBAA1FD4B0B8D56B351BC7B277F4 /* Label.swift in Sources */ = {isa = PBXBuildFile; fileRef = 288D4CA144C64E07905184F6CBAAE867 /* Label.swift */; };
+		E09FEFAFFD39157648FFABB51E2EB3EA /* NormalizedCoordinate+Locations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C79CDE470DD3341A0A34BD1C052A973 /* NormalizedCoordinate+Locations.swift */; };
+		E11FF4E3610B51833B5B25BFEC9439EB /* Array+Safe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44A8EB04ABAA59D35775222D7010AA51 /* Array+Safe.swift */; };
+		E3AA3BD0B36A8D7D0DDADCA23C123130 /* Stepper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 996EB6D6F78C53D2C9B5D4FBC4C13D84 /* Stepper.swift */; };
+		E558577851F19778E543AE6D7DCFF30A /* Springboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A9E2EEC134947F1BCADD81AFCF32A5B /* Springboard.swift */; };
+		E87367920E610653998714517B01869C /* View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3343170286ADD343A663D64B81BB398B /* View.swift */; };
+		E9BA1D90C07B623069A2D6BB1686441B /* TextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BEC99316035011631C40BFCF3197901 /* TextView.swift */; };
+		EBD37C76644005FA6D30F6FCAA57EA58 /* Keyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB2B8E3108E83AEF1A861292D5E667A5 /* Keyboard.swift */; };
+		EE7661A93B9C6E26F9D8C1D89491F76E /* Pods-TABTestKit_Example-TABTestKit_ExampleUITests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 99E06D4FF45A3B2605A88BF7D8DDC1C9 /* Pods-TABTestKit_Example-TABTestKit_ExampleUITests-dummy.m */; };
+		F19E657512049CDD2FD1414E408073C8 /* CGVector+Offset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 409D0012B0FB4B730BAB1D8F54421886 /* CGVector+Offset.swift */; };
+		F566D30798059D2B906BF3245752870F /* ValueRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42287AC46DDDC0D1AA7184E181C68C89 /* ValueRepresentable.swift */; };
+		F67B7C7FDE9074CDCFA68E004947AA92 /* Element+defaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AE3694A3ADDFDB10E97129C26B4C12F /* Element+defaults.swift */; };
+		FB0F482C6EC685FC996684E7E0C58A81 /* Scenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1AB2E805D93F75BF37BD873B9BF6585 /* Scenario.swift */; };
+		FB1E11C5834A94EA4E92203A824C7712 /* Image.swift in Sources */ = {isa = PBXBuildFile; fileRef = 310D0511477295F4E8D3A2CECA4D953A /* Image.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		04C0ED95764AD70BF43EFA78B032313B /* PBXContainerItemProxy */ = {
+		08A99BEA9208FCFDB1062DADA9B40487 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9C1FEFBBC00DBFB4EC56C99126E8E9B0;
+			remoteInfo = ShowTime;
+		};
+		34A9B585AC52D00944BC81029C8F615A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9C1FEFBBC00DBFB4EC56C99126E8E9B0;
+			remoteInfo = ShowTime;
+		};
+		F598D08DAB210C6E35AA46DCC7485897 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 9C4F771642E79689CC6A0648ABEA808C;
 			remoteInfo = TABTestKit;
 		};
-		0BF10D5355C2C44AED2A9D0480F98BF0 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 9C1FEFBBC00DBFB4EC56C99126E8E9B0;
-			remoteInfo = ShowTime;
-		};
-		5E46CC12080B1A9E37FBD7588D02584F /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 9C1FEFBBC00DBFB4EC56C99126E8E9B0;
-			remoteInfo = ShowTime;
-		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		029ACEB452A14FC499201FC3B0C4ED34 /* ScrollableScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ScrollableScreen.swift; sourceTree = "<group>"; };
+		00B178BBB394C26212D58AE9F1A3376E /* XCUIElement+isVisible.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "XCUIElement+isVisible.swift"; sourceTree = "<group>"; };
 		033A36A29482FD32230FE0CA177F9BD3 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.2.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		06062B1405E6248957F1FA51ED99AEAE /* Tappable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Tappable.swift; sourceTree = "<group>"; };
-		0D9B3886BA63D85E95DC7C0E2C41C9C9 /* SystemPreferencesResetScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SystemPreferencesResetScreen.swift; sourceTree = "<group>"; };
+		063860976CBFED0CEABD0E3213F93A8E /* BaseApp.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BaseApp.swift; sourceTree = "<group>"; };
+		0930640B9F785B2533E020EBE1A83252 /* Table.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Table.swift; sourceTree = "<group>"; };
+		0AE3694A3ADDFDB10E97129C26B4C12F /* Element+defaults.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Element+defaults.swift"; sourceTree = "<group>"; };
+		0AF0A2E0D69C6A4EF1AB4402DB0A38EA /* TABTestKit-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "TABTestKit-Info.plist"; sourceTree = "<group>"; };
+		0C38F549CCB18E20A90695795AEC5AC6 /* Refreshable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Refreshable.swift; sourceTree = "<group>"; };
+		10B1611A1B50B1DA5565DB251CBF81F4 /* TABTestKit.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = TABTestKit.debug.xcconfig; sourceTree = "<group>"; };
+		1146247962F18FFC769B180EB17B0A5D /* PageIndicator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PageIndicator.swift; sourceTree = "<group>"; };
+		11F2A3A2A26E9B32CC1F97EE09E1F276 /* Scrollable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Scrollable.swift; sourceTree = "<group>"; };
+		13B5D2EB83CCADFD7A1E0058D8A2B609 /* Attributes.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Attributes.swift; sourceTree = "<group>"; };
+		13BA1BD868EA98BFAF1291D67025BC2E /* TABTestKit.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = TABTestKit.modulemap; sourceTree = "<group>"; };
 		14146CA31421B9CAE5A93C48F6E9FFAF /* Pods-TABTestKit_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-TABTestKit_Example.debug.xcconfig"; sourceTree = "<group>"; };
-		1535CFEC7782CBF5925C8C4087599AF0 /* Dismissable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Dismissable.swift; sourceTree = "<group>"; };
 		17AE207B2FD67E1096C542744391C322 /* Pods-TABTestKit_Example-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-TABTestKit_Example-acknowledgements.plist"; sourceTree = "<group>"; };
-		17DCECBA4EAAE4C07053D26FBE892D78 /* App.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = App.swift; sourceTree = "<group>"; };
-		1A139CE57C53F627624E7B2244D19E74 /* TabBar.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TabBar.swift; sourceTree = "<group>"; };
+		1B0AB1F764B8B3C263215AFEFC01143A /* Cell.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Cell.swift; sourceTree = "<group>"; };
 		1CB830EB632DA8DED42D4E33C4E59DD9 /* Pods-TABTestKit_Example-TABTestKit_ExampleUITests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-TABTestKit_Example-TABTestKit_ExampleUITests-frameworks.sh"; sourceTree = "<group>"; };
-		1FEECC2891FA9207E48C23F05FA63331 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; path = LICENSE; sourceTree = "<group>"; };
-		20F6759CD9CFC4C1F5DA6B78EFFBB609 /* SystemPreferencesContext.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SystemPreferencesContext.swift; sourceTree = "<group>"; };
-		2120EE906455FB83E2E09406CEF662C9 /* SegmentedControl.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SegmentedControl.swift; sourceTree = "<group>"; };
-		2139B5533BEBB89B1AAED6BD36926681 /* TABTestKit.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = TABTestKit.release.xcconfig; sourceTree = "<group>"; };
-		233D9F6DE5B7ED9B213DDEE7A60DF4D2 /* Editable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Editable.swift; sourceTree = "<group>"; };
-		238D94DB52E866485358E8A0DB1C35AF /* CGVector+Offset.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "CGVector+Offset.swift"; sourceTree = "<group>"; };
+		21A5843633E4D75EE8E1556F939DB746 /* SystemPreferencesResetScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SystemPreferencesResetScreen.swift; sourceTree = "<group>"; };
 		246C5312AD287517A78640A4FAF48421 /* ShowTime.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = ShowTime.framework; path = ShowTime.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		26E0C2DB87953FDF97B668A8BE0A744E /* SecureTextField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SecureTextField.swift; sourceTree = "<group>"; };
+		270FD9B498764D8FEA3F42DB3007EE80 /* Sheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Sheet.swift; sourceTree = "<group>"; };
+		2729792DB920A36618545DE30B46AA58 /* XCUIElement+hasKeyboardFocus.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "XCUIElement+hasKeyboardFocus.swift"; sourceTree = "<group>"; };
 		28061D8B4A5060F09E692D4BC586713B /* Pods-TABTestKit_Example-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-TABTestKit_Example-dummy.m"; sourceTree = "<group>"; };
-		288348B0E48E8832F351BC7B63303777 /* Icon.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Icon.swift; sourceTree = "<group>"; };
-		2ADFBF8A19DAC2594ED4548F1696E8C9 /* SystemPreferences.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SystemPreferences.swift; sourceTree = "<group>"; };
+		288D4CA144C64E07905184F6CBAAE867 /* Label.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Label.swift; sourceTree = "<group>"; };
+		28FC2FFEC625B0FA3CD74A1DA0360038 /* XCTFatalFail.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = XCTFatalFail.swift; sourceTree = "<group>"; };
+		2BEC99316035011631C40BFCF3197901 /* TextView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TextView.swift; sourceTree = "<group>"; };
 		2C061463250766C9C05995AB8EE63E66 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.2.sdk/System/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
+		2E96D37C7B544B5D3F8FABFDB3A65DFD /* TextField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TextField.swift; sourceTree = "<group>"; };
 		2E97F8EAABEDB0295C8BBA3ADB4A81C2 /* Pods_TABTestKit_Example_TABTestKit_ExampleUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_TABTestKit_Example_TABTestKit_ExampleUITests.framework; path = "Pods-TABTestKit_Example-TABTestKit_ExampleUITests.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		2EB66BEA4359AD0F6E58CE8E61A7D651 /* ScrollView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ScrollView.swift; sourceTree = "<group>"; };
-		30B66790D2082BEC84983A6EF4BF5662 /* WebView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebView.swift; sourceTree = "<group>"; };
-		34B6C40BC468C579D69B2CC4CAF320EC /* Label.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Label.swift; sourceTree = "<group>"; };
-		37CD9BB357BD4C98594C6FDB2372E203 /* Keyboard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Keyboard.swift; sourceTree = "<group>"; };
-		3A6FE0B2CF948C41E54AA50B9A2DBFE6 /* CollectionView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CollectionView.swift; sourceTree = "<group>"; };
-		3ABBEEBD584246EF61D103CF1C923A0E /* BiometricsContext.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BiometricsContext.swift; sourceTree = "<group>"; };
-		428C7E1FA710CF3CFD6B1D091E8DA215 /* TextField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TextField.swift; sourceTree = "<group>"; };
-		43D13F1FAF8603F38A44BA21F33C0912 /* TABTestKit.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; path = TABTestKit.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		44F9BE5C5077780745214E80112EF7EF /* Refreshable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Refreshable.swift; sourceTree = "<group>"; };
-		48F3EF5E147F848C915D2D095DFA422D /* NavigationContext.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NavigationContext.swift; sourceTree = "<group>"; };
+		310D0511477295F4E8D3A2CECA4D953A /* Image.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Image.swift; sourceTree = "<group>"; };
+		31BB533F397C5D4FD9F1F0910B521877 /* NavBar.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NavBar.swift; sourceTree = "<group>"; };
+		3343170286ADD343A663D64B81BB398B /* View.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = View.swift; sourceTree = "<group>"; };
+		378BEB1C3B86DE939F26118388E95363 /* Safari.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Safari.swift; sourceTree = "<group>"; };
+		39F10CDF64864F18B3EEAAE5618F2993 /* TABTestKit-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "TABTestKit-umbrella.h"; sourceTree = "<group>"; };
+		409D0012B0FB4B730BAB1D8F54421886 /* CGVector+Offset.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "CGVector+Offset.swift"; sourceTree = "<group>"; };
+		42287AC46DDDC0D1AA7184E181C68C89 /* ValueRepresentable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ValueRepresentable.swift; sourceTree = "<group>"; };
+		44A8EB04ABAA59D35775222D7010AA51 /* Array+Safe.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Array+Safe.swift"; sourceTree = "<group>"; };
+		44D3D373915DB3F443D51C091A399226 /* AlertContext.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AlertContext.swift; sourceTree = "<group>"; };
+		4A9E2EEC134947F1BCADD81AFCF32A5B /* Springboard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Springboard.swift; sourceTree = "<group>"; };
+		5029125F64A9A19889E338765CD0299E /* TABTestKit.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; path = TABTestKit.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		516836C45DBE97859AF1DD3AC2CD4B01 /* Pods_TABTestKit_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_TABTestKit_Example.framework; path = "Pods-TABTestKit_Example.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		526C28167B8EB919F428D251486F18A3 /* Element.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Element.swift; sourceTree = "<group>"; };
-		539E3535E6A4796A5DC1359080B1B388 /* SecureTextField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SecureTextField.swift; sourceTree = "<group>"; };
+		516FEC36F601143A1A7D9C4483043E02 /* Biometrics.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = Biometrics.m; sourceTree = "<group>"; };
+		525F300EF39DA23BCE9573EFDF316426 /* TabBar.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TabBar.swift; sourceTree = "<group>"; };
 		549B858328CB2EF8360076242052506E /* Pods-TABTestKit_Example.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-TABTestKit_Example.modulemap"; sourceTree = "<group>"; };
-		58701D6FE5B0819E5ECE654224188DC0 /* AlertContext.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AlertContext.swift; sourceTree = "<group>"; };
-		5B5CC92563CE4BC7DA55A6394BD6A1DA /* TABTestCase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TABTestCase.swift; path = TABTestKit/Classes/TABTestCase.swift; sourceTree = "<group>"; };
+		58185D0DA6046583EA0F3992B136C18F /* XCUIElement+wait.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "XCUIElement+wait.swift"; sourceTree = "<group>"; };
 		5C817F0E0208382B131E5FFB430F8A17 /* TABTestKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = TABTestKit.framework; path = TABTestKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		5D9D28DCEEADE9294B60676002E5F3AF /* XCUIElement+wait.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "XCUIElement+wait.swift"; sourceTree = "<group>"; };
-		5E21D12E79B060EEABD6D9C064FD58DC /* AppContext.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppContext.swift; sourceTree = "<group>"; };
-		5EADE617313EDEFAE09DD75B5F7B1B98 /* TABTestKit.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = TABTestKit.debug.xcconfig; sourceTree = "<group>"; };
-		5EE536BF6DFF2331078DBAADAAB49035 /* Cell.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Cell.swift; sourceTree = "<group>"; };
-		5FD98E1ABC6B6C0E1972A84DF17C5101 /* CellContaining.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CellContaining.swift; sourceTree = "<group>"; };
-		609F80835D951294E6054EC34BE7DEAB /* SheetContext.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SheetContext.swift; sourceTree = "<group>"; };
-		63808F52E6B612D9117EA7F81237AAED /* Alert.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Alert.swift; sourceTree = "<group>"; };
+		5E1A9256A8DD33C89BAAB57A235F2804 /* Adjustable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Adjustable.swift; sourceTree = "<group>"; };
+		5EFFE450A2ED2E1A13F6291EF95C4F19 /* Header.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Header.swift; sourceTree = "<group>"; };
 		69152FFA4489AC24B45BCE5208B3B41A /* ShowTime-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "ShowTime-umbrella.h"; sourceTree = "<group>"; };
-		6980B17C7DE4DADEAE4CC75D703C54AC /* Header.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Header.swift; sourceTree = "<group>"; };
-		6AEC6A3A9A1E90D3C5F4B4A736C8E946 /* systemPreferencesRootScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = systemPreferencesRootScreen.swift; sourceTree = "<group>"; };
-		6E78188EC60ABEC11AE165500D2CFFCB /* Array+Safe.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Array+Safe.swift"; sourceTree = "<group>"; };
+		6B82B2F93A1BE5B4C63A8A4CB66E2BE9 /* SegmentedControl.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SegmentedControl.swift; sourceTree = "<group>"; };
 		6E79134F82F3A8D58969B44D7F169338 /* Pods-TABTestKit_Example-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-TABTestKit_Example-acknowledgements.markdown"; sourceTree = "<group>"; };
-		71AC18C8449F986EBB02832E2A07A50F /* NavBar.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NavBar.swift; sourceTree = "<group>"; };
-		71BC30DBECCC085046C14F79A51C96FC /* Slider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Slider.swift; sourceTree = "<group>"; };
-		7E675701574C76D0C286A4F6FFFFB5E5 /* Stepper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Stepper.swift; sourceTree = "<group>"; };
-		7FDC2516655ADE505B015B6C694D2328 /* Sheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Sheet.swift; sourceTree = "<group>"; };
-		801D065A67CFE384AC907A0A08A80669 /* Biometrics.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = Biometrics.h; sourceTree = "<group>"; };
-		825F5BBC95C9AD5A6FEF97516F438976 /* Biometrics-Bridging-Header.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Biometrics-Bridging-Header.h"; sourceTree = "<group>"; };
-		82E2D18AF412B9ED1E41630009454979 /* Step.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Step.swift; sourceTree = "<group>"; };
-		8A3EB354FF57A4D5DF54965C128B21F6 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; path = README.md; sourceTree = "<group>"; };
-		8BF44A3860DAFA6F569C7C830A6F42C2 /* PageIndicator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PageIndicator.swift; sourceTree = "<group>"; };
-		8BFD6C0764CD43FFB743CE603C9FFD68 /* Button.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Button.swift; sourceTree = "<group>"; };
-		8D4D2A880C74185B385459D0F3ECFC51 /* TABTestKit.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = TABTestKit.modulemap; sourceTree = "<group>"; };
-		9089417F0109865CDB124A2329BDD6FB /* Table.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Table.swift; sourceTree = "<group>"; };
+		733C9EB16F7A1DF6E9E333F54B511D02 /* Completable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Completable.swift; sourceTree = "<group>"; };
+		76218D3926FC14AD26D4F85F24A78116 /* TABTestKit-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "TABTestKit-dummy.m"; sourceTree = "<group>"; };
+		76351B41B9C4CCADF915B35D11C74EAC /* Biometrics-Bridging-Header.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Biometrics-Bridging-Header.h"; sourceTree = "<group>"; };
+		7EECF51F8060F5B8BFA4281A38586E83 /* Screen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Screen.swift; sourceTree = "<group>"; };
+		833F3150E7163B9CDD9DC3F6667D24AE /* Switch.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Switch.swift; sourceTree = "<group>"; };
 		91B1EB1FAB79CE231C85712DE4D31CC0 /* Pods-TABTestKit_Example-TABTestKit_ExampleUITests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-TABTestKit_Example-TABTestKit_ExampleUITests-acknowledgements.plist"; sourceTree = "<group>"; };
-		9428A8F167FEB42DE18A7EBD813A80A5 /* KeyboardContext.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = KeyboardContext.swift; sourceTree = "<group>"; };
+		9636ED3E95A98C45C798682289AABB5A /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; path = README.md; sourceTree = "<group>"; };
 		965A292F186CF36A47FF8AB1CADE1B85 /* Pods-TABTestKit_Example-TABTestKit_ExampleUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-TABTestKit_Example-TABTestKit_ExampleUITests.release.xcconfig"; sourceTree = "<group>"; };
-		96FC8F190C24B476CD216A18EC6FFCF2 /* TABTestKit-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "TABTestKit-Info.plist"; sourceTree = "<group>"; };
-		987BEA52658B9CB88A6F751D324F13AD /* TABTestKit-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "TABTestKit-dummy.m"; sourceTree = "<group>"; };
+		97B6600289CF1454BB2B7A95FE5523AB /* Slider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Slider.swift; sourceTree = "<group>"; };
+		99645CE216E89A6655EC66E732CECD38 /* Element.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Element.swift; sourceTree = "<group>"; };
+		996EB6D6F78C53D2C9B5D4FBC4C13D84 /* Stepper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Stepper.swift; sourceTree = "<group>"; };
 		99E06D4FF45A3B2605A88BF7D8DDC1C9 /* Pods-TABTestKit_Example-TABTestKit_ExampleUITests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-TABTestKit_Example-TABTestKit_ExampleUITests-dummy.m"; sourceTree = "<group>"; };
+		9C79CDE470DD3341A0A34BD1C052A973 /* NormalizedCoordinate+Locations.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "NormalizedCoordinate+Locations.swift"; sourceTree = "<group>"; };
+		9D132E7F63ED7978B99EF4975197150F /* ScrollableScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ScrollableScreen.swift; sourceTree = "<group>"; };
 		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		9DB84493C64353132E6F27571A43A3F6 /* CollectionView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CollectionView.swift; sourceTree = "<group>"; };
 		9FEFF9CD73B2D6723ED60BBDD46577CD /* Pods-TABTestKit_Example-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-TABTestKit_Example-umbrella.h"; sourceTree = "<group>"; };
+		A361D13461D8EC6C08FFF31BDF8D1806 /* BiometricsContext.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BiometricsContext.swift; sourceTree = "<group>"; };
+		A3EE8B1C53D5F26ACBFF010AEABAE28B /* Dismissable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Dismissable.swift; sourceTree = "<group>"; };
 		A3F9B3AEE6873539F9B3FD0F64E7DB43 /* Pods-TABTestKit_Example-TABTestKit_ExampleUITests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-TABTestKit_Example-TABTestKit_ExampleUITests-acknowledgements.markdown"; sourceTree = "<group>"; };
-		A44D97A79485D765FFC1885EF486035C /* TextView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TextView.swift; sourceTree = "<group>"; };
-		A4F037B014CEDE4C8F4E39CB25E05DD2 /* Switch.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Switch.swift; sourceTree = "<group>"; };
 		AA47AB426A72CF612E6CDF50B0E91C8F /* ShowTime.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = ShowTime.debug.xcconfig; sourceTree = "<group>"; };
 		AA9FC38AC03409CABA3E4DD246E3CF1C /* ShowTime-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "ShowTime-prefix.pch"; sourceTree = "<group>"; };
 		AB4E151C064820753E3685012C75D924 /* Pods-TABTestKit_Example-TABTestKit_ExampleUITests-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-TABTestKit_Example-TABTestKit_ExampleUITests-Info.plist"; sourceTree = "<group>"; };
-		AB73F3D5CE27BEFC135A72853A578770 /* View.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = View.swift; sourceTree = "<group>"; };
 		ADB4763ABC911105EE431BA516439FE1 /* ShowTime.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = ShowTime.modulemap; sourceTree = "<group>"; };
 		AFD57256DAD4C8414BD38FD34982C7B0 /* Pods-TABTestKit_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-TABTestKit_Example.release.xcconfig"; sourceTree = "<group>"; };
-		B10C6E6AABDEF73C8D9E647494F5FFFD /* Safari.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Safari.swift; sourceTree = "<group>"; };
-		B6FEDCB8E835BAD94013EC96B36228F2 /* BaseApp.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BaseApp.swift; sourceTree = "<group>"; };
-		BA5720DEDCE2EE95A4B4F67D967D49EE /* Biometrics.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = Biometrics.m; sourceTree = "<group>"; };
-		BBE255692AD510B938CB0017AEED4518 /* TABTestKit-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "TABTestKit-prefix.pch"; sourceTree = "<group>"; };
-		C0E4EAF339F88D5CC4828E58D2D044BA /* Attributes.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Attributes.swift; sourceTree = "<group>"; };
+		B16CB0412D2D22CA01914F6BAE91169D /* Step.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Step.swift; sourceTree = "<group>"; };
+		B34195E62CE6D4325A0363AF69BD0FB9 /* KeyboardContext.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = KeyboardContext.swift; sourceTree = "<group>"; };
+		B62E07EF0C9BE6DEF51F0BE719EFEB9E /* AppContext.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppContext.swift; sourceTree = "<group>"; };
+		B8889DDD0297F197C953F944C127449C /* WebView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebView.swift; sourceTree = "<group>"; };
+		B8F3ADBAFBD856493872E3528629CE26 /* Picker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Picker.swift; sourceTree = "<group>"; };
+		B906394D23C1F041CA4124C3B1FFF2F3 /* Button.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Button.swift; sourceTree = "<group>"; };
+		B99BC68F60289EE3D2B827C55151ED07 /* Icon.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Icon.swift; sourceTree = "<group>"; };
+		BD2E454FE7393A49B62A15ECF95C55AF /* SheetContext.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SheetContext.swift; sourceTree = "<group>"; };
 		C354231844F21D916AF8E0D9E0F587FF /* Pods-TABTestKit_Example-TABTestKit_ExampleUITests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-TABTestKit_Example-TABTestKit_ExampleUITests.modulemap"; sourceTree = "<group>"; };
-		C4168F73CEF3298398FAFE1F3755C496 /* Adjustable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Adjustable.swift; sourceTree = "<group>"; };
 		C6AFBB671D10E6AEF0786D8E3E16BDE4 /* Pods-TABTestKit_Example-TABTestKit_ExampleUITests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-TABTestKit_Example-TABTestKit_ExampleUITests-umbrella.h"; sourceTree = "<group>"; };
-		CA36B114B42B335BCF6F8F96ED83733E /* SystemPreferencesGeneralScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SystemPreferencesGeneralScreen.swift; sourceTree = "<group>"; };
+		C886680EDE8E68E288F0B0967127256D /* SystemPreferencesContext.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SystemPreferencesContext.swift; sourceTree = "<group>"; };
+		C9017D3505D12281FD18FE6120B0A5DE /* TABTestCase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TABTestCase.swift; path = TABTestKit/Classes/TABTestCase.swift; sourceTree = "<group>"; };
+		CB2B8E3108E83AEF1A861292D5E667A5 /* Keyboard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Keyboard.swift; sourceTree = "<group>"; };
 		CBA3199C63C53E992A3F26F5ADCBB639 /* Pods-TABTestKit_Example-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-TABTestKit_Example-Info.plist"; sourceTree = "<group>"; };
-		CC8682021049AEAAB3DCD7C150A95FB2 /* ActivitySheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ActivitySheet.swift; sourceTree = "<group>"; };
-		CD112D38CB4A7946791170C90730CC9D /* XCUIElement+hasKeyboardFocus.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "XCUIElement+hasKeyboardFocus.swift"; sourceTree = "<group>"; };
-		CD37B9C8E065DD3D17F7204B1B1FBD58 /* Element+defaults.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Element+defaults.swift"; sourceTree = "<group>"; };
-		D07C967D9F11E4E64FCCB0515B63C928 /* Picker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Picker.swift; sourceTree = "<group>"; };
-		D62EEF2B33953AEF764BCFFC3597CF30 /* Scenario.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Scenario.swift; sourceTree = "<group>"; };
-		D8F71C696D13A19D07E5810318AA9384 /* XCUIDevice+frame.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "XCUIDevice+frame.swift"; sourceTree = "<group>"; };
-		DBE7A8817DB54096950BC6C6163FB2C0 /* XCTFatalFail.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = XCTFatalFail.swift; sourceTree = "<group>"; };
-		DC8E6BB8E22FC1B0C1930A4F8B678E92 /* ValueRepresentable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ValueRepresentable.swift; sourceTree = "<group>"; };
-		DE2ACC1384856F32BDEAF0B67C4ABBA6 /* Springboard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Springboard.swift; sourceTree = "<group>"; };
+		D1AB2E805D93F75BF37BD873B9BF6585 /* Scenario.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Scenario.swift; sourceTree = "<group>"; };
+		D3B5FEA5DCDCA2D582C00DE6B76CDC0B /* ScrollView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ScrollView.swift; sourceTree = "<group>"; };
+		D5A869D57AC8EDD0ED0BC6DA6BD96660 /* DatePicker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DatePicker.swift; sourceTree = "<group>"; };
+		D633AFB6915D96D516CD0872E60E2415 /* App.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = App.swift; sourceTree = "<group>"; };
+		D87AACBC58E2252912FEC4132CF481CE /* TABTestKit-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "TABTestKit-prefix.pch"; sourceTree = "<group>"; };
+		D91666C6805484361A8042FE298F3C08 /* InteractionContext.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = InteractionContext.swift; sourceTree = "<group>"; };
 		DF441583F13AEDF6DF852C5354F264E1 /* ShowTime-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "ShowTime-Info.plist"; sourceTree = "<group>"; };
-		E0A11CCC52D92B046F8A9FA9AC99AF4F /* Image.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Image.swift; sourceTree = "<group>"; };
-		E34A4D0E90CA84F5B686ECC33E84720D /* InteractionContext.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = InteractionContext.swift; sourceTree = "<group>"; };
-		E69262C4F4A355BF4676D44D72262A23 /* Completable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Completable.swift; sourceTree = "<group>"; };
-		E78108E38AC455729C36C4C7EEDE146C /* NormalizedCoordinate+Locations.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "NormalizedCoordinate+Locations.swift"; sourceTree = "<group>"; };
+		E4508197147D357E5AC5F92B14089EC1 /* SystemPreferences.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SystemPreferences.swift; sourceTree = "<group>"; };
+		E59DB98EC39EB118496B12CB4BE9C95C /* Alert.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Alert.swift; sourceTree = "<group>"; };
+		E846D1B6D74DE542E5CA9527BD39F15F /* Tappable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Tappable.swift; sourceTree = "<group>"; };
+		E8D0C69508B528128406927836573B67 /* systemPreferencesRootScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = systemPreferencesRootScreen.swift; sourceTree = "<group>"; };
+		E97F64AF467C08D1FB58F73CF59C7EB4 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; path = LICENSE; sourceTree = "<group>"; };
 		EAF2F2B8E583A5D847949453BAC20C6B /* ShowTime.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ShowTime.swift; path = Sources/ShowTime/ShowTime.swift; sourceTree = "<group>"; };
-		EC56A10DF2C24631522AEF8CBF30B351 /* XCUIElement+isVisible.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "XCUIElement+isVisible.swift"; sourceTree = "<group>"; };
 		EC7677F7A126781D8591BE7C185D48F7 /* Pods-TABTestKit_Example-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-TABTestKit_Example-frameworks.sh"; sourceTree = "<group>"; };
-		F00418B0925C8A96D09D1986BE6C1B6B /* TABTestKit-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "TABTestKit-umbrella.h"; sourceTree = "<group>"; };
+		EDF4947C9E27BB97B30F06939F64E9E0 /* CellContaining.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CellContaining.swift; sourceTree = "<group>"; };
+		EF3CF5B9ABEEA0EDC977AFA1D3653700 /* ActivitySheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ActivitySheet.swift; sourceTree = "<group>"; };
+		EFE83F853FC56745500A916FBFE0BD09 /* SystemPreferencesGeneralScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SystemPreferencesGeneralScreen.swift; sourceTree = "<group>"; };
 		F094F44DD0301CC76E1365673D3FCF9C /* ShowTime-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "ShowTime-dummy.m"; sourceTree = "<group>"; };
-		F91B925F791557160A72CB6C0BA49D45 /* Scrollable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Scrollable.swift; sourceTree = "<group>"; };
-		FB18014FAD1F5EE5FA9E004624623989 /* Screen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Screen.swift; sourceTree = "<group>"; };
+		F2F76C444323B6EB045D04A8CE4B6F18 /* NavigationContext.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NavigationContext.swift; sourceTree = "<group>"; };
+		F3F8FE35B25F667403E340317EA9F9FD /* TABTestKit.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = TABTestKit.release.xcconfig; sourceTree = "<group>"; };
+		F5109E1F024CAEEB532DC9DC19512FF1 /* XCUIDevice+frame.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "XCUIDevice+frame.swift"; sourceTree = "<group>"; };
+		F5D608343740CFA224AF053B57F66F67 /* Editable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Editable.swift; sourceTree = "<group>"; };
+		FBA47936DBE7936C98F0EC94B9E8CEAC /* Biometrics.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = Biometrics.h; sourceTree = "<group>"; };
 		FD03AA75DD58014781A38E023C12CD42 /* ShowTime.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = ShowTime.release.xcconfig; sourceTree = "<group>"; };
 		FDC54A8EC562A73143E238094E80179D /* Pods-TABTestKit_Example-TABTestKit_ExampleUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-TABTestKit_Example-TABTestKit_ExampleUITests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -242,52 +244,48 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		434AAE768A8C9EA8DFD951F6ABAC9D5C /* Frameworks */ = {
+		4898BC30FDFD419F968119FDEDDF05A7 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A3D01C0F1E1F3BD46CBE767C7A2BD535 /* Foundation.framework in Frameworks */,
+				4DF904622DBED25D617FB92185ACCAF7 /* Foundation.framework in Frameworks */,
+				33A0126A9943D162EDCC4DE493D8A168 /* XCTest.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		85DE561D3E4964DDC1F5E827216CDF49 /* Frameworks */ = {
+		C5F45EBFBA89156FDAD636437B27CAAE /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				28C2F366D4A968DBCF276D13CF9EF6CF /* Foundation.framework in Frameworks */,
+				074443E7511027A2E5ED3909C0EA4C9B /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		FE2EECB8103069FC9D094A9453F0E5E4 /* Frameworks */ = {
+		DA6508EB8D221EE762ADFF8A3478C2C9 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F9323849E50840C3CC8D3EA197513D5E /* Foundation.framework in Frameworks */,
-				057AD19E80F1F6E17D80CDC554C0E41F /* XCTest.framework in Frameworks */,
+				DA63C2BDCDFB0A29EF5D49EDF95724BF /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		0B3D003A7C1077A3F04902E11EE2D428 /* Protocols */ = {
+		09D33B2E9C4207D5883730B1CC953ACA /* Contexts */ = {
 			isa = PBXGroup;
 			children = (
-				C4168F73CEF3298398FAFE1F3755C496 /* Adjustable.swift */,
-				5FD98E1ABC6B6C0E1972A84DF17C5101 /* CellContaining.swift */,
-				E69262C4F4A355BF4676D44D72262A23 /* Completable.swift */,
-				1535CFEC7782CBF5925C8C4087599AF0 /* Dismissable.swift */,
-				233D9F6DE5B7ED9B213DDEE7A60DF4D2 /* Editable.swift */,
-				526C28167B8EB919F428D251486F18A3 /* Element.swift */,
-				44F9BE5C5077780745214E80112EF7EF /* Refreshable.swift */,
-				FB18014FAD1F5EE5FA9E004624623989 /* Screen.swift */,
-				F91B925F791557160A72CB6C0BA49D45 /* Scrollable.swift */,
-				029ACEB452A14FC499201FC3B0C4ED34 /* ScrollableScreen.swift */,
-				06062B1405E6248957F1FA51ED99AEAE /* Tappable.swift */,
-				DC8E6BB8E22FC1B0C1930A4F8B678E92 /* ValueRepresentable.swift */,
+				44D3D373915DB3F443D51C091A399226 /* AlertContext.swift */,
+				B62E07EF0C9BE6DEF51F0BE719EFEB9E /* AppContext.swift */,
+				A361D13461D8EC6C08FFF31BDF8D1806 /* BiometricsContext.swift */,
+				D91666C6805484361A8042FE298F3C08 /* InteractionContext.swift */,
+				B34195E62CE6D4325A0363AF69BD0FB9 /* KeyboardContext.swift */,
+				F2F76C444323B6EB045D04A8CE4B6F18 /* NavigationContext.swift */,
+				BD2E454FE7393A49B62A15ECF95C55AF /* SheetContext.swift */,
+				C886680EDE8E68E288F0B0967127256D /* SystemPreferencesContext.swift */,
 			);
-			name = Protocols;
-			path = TABTestKit/Classes/Protocols;
+			name = Contexts;
+			path = TABTestKit/Classes/Contexts;
 			sourceTree = "<group>";
 		};
 		0EAD851B593C7D383A5B9F66278D5202 /* ShowTime */ = {
@@ -298,25 +296,6 @@
 			);
 			name = ShowTime;
 			path = ShowTime;
-			sourceTree = "<group>";
-		};
-		13156ED4460199C179A65E78131501C9 /* TABTestKit */ = {
-			isa = PBXGroup;
-			children = (
-				5B5CC92563CE4BC7DA55A6394BD6A1DA /* TABTestCase.swift */,
-				8872C50C8A2611470A75161595B511D1 /* Apps */,
-				868B417AD73B1B721B53EAAD193BB43C /* BDD */,
-				3F8ED93EBF60DA466D13FAEA865C7534 /* Biometrics */,
-				84077031334557DE7388627A56AB6D8E /* Contexts */,
-				7FD44DEFF2C312F744D47FD7616C45B6 /* Elements */,
-				AD21999C0E45239ADD1FC10D908F2545 /* Extensions */,
-				9302C6E69E759D3BC0598249955E45CD /* Pod */,
-				0B3D003A7C1077A3F04902E11EE2D428 /* Protocols */,
-				93861C173157E253A42A264F81336254 /* Screens */,
-				ED03717EC67D68756D0CA0452BCCD549 /* Support Files */,
-			);
-			name = TABTestKit;
-			path = ../..;
 			sourceTree = "<group>";
 		};
 		1628BF05B4CAFDCC3549A101F5A10A17 /* Frameworks */ = {
@@ -330,7 +309,7 @@
 		18BB3C90BDF1A5F1D336E77B09EBB1F2 /* Development Pods */ = {
 			isa = PBXGroup;
 			children = (
-				13156ED4460199C179A65E78131501C9 /* TABTestKit */,
+				F6B926016CF4E01F84A53067AEAFC3D1 /* TABTestKit */,
 			);
 			name = "Development Pods";
 			sourceTree = "<group>";
@@ -363,6 +342,33 @@
 			path = "Target Support Files/Pods-TABTestKit_Example";
 			sourceTree = "<group>";
 		};
+		2FA8FCAA9775EF55974403A605D05230 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				44A8EB04ABAA59D35775222D7010AA51 /* Array+Safe.swift */,
+				409D0012B0FB4B730BAB1D8F54421886 /* CGVector+Offset.swift */,
+				0AE3694A3ADDFDB10E97129C26B4C12F /* Element+defaults.swift */,
+				9C79CDE470DD3341A0A34BD1C052A973 /* NormalizedCoordinate+Locations.swift */,
+				28FC2FFEC625B0FA3CD74A1DA0360038 /* XCTFatalFail.swift */,
+				F5109E1F024CAEEB532DC9DC19512FF1 /* XCUIDevice+frame.swift */,
+				2729792DB920A36618545DE30B46AA58 /* XCUIElement+hasKeyboardFocus.swift */,
+				00B178BBB394C26212D58AE9F1A3376E /* XCUIElement+isVisible.swift */,
+				58185D0DA6046583EA0F3992B136C18F /* XCUIElement+wait.swift */,
+			);
+			name = Extensions;
+			path = TABTestKit/Classes/Extensions;
+			sourceTree = "<group>";
+		};
+		351F0940FBB3A7248B16461D572961DD /* BDD */ = {
+			isa = PBXGroup;
+			children = (
+				D1AB2E805D93F75BF37BD873B9BF6585 /* Scenario.swift */,
+				B16CB0412D2D22CA01914F6BAE91169D /* Step.swift */,
+			);
+			name = BDD;
+			path = TABTestKit/Classes/BDD;
+			sourceTree = "<group>";
+		};
 		3AD53452E6F9B27B718A63F5668EEEAC /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
@@ -387,11 +393,80 @@
 			name = iOS;
 			sourceTree = "<group>";
 		};
-		3F8ED93EBF60DA466D13FAEA865C7534 /* Biometrics */ = {
+		456C8615377475D12A602BADDD74F8AC /* Elements */ = {
 			isa = PBXGroup;
 			children = (
-				BA5720DEDCE2EE95A4B4F67D967D49EE /* Biometrics.m */,
-				E4AB311632441689EE39961281F1DCDF /* include */,
+				EF3CF5B9ABEEA0EDC977AFA1D3653700 /* ActivitySheet.swift */,
+				E59DB98EC39EB118496B12CB4BE9C95C /* Alert.swift */,
+				13B5D2EB83CCADFD7A1E0058D8A2B609 /* Attributes.swift */,
+				B906394D23C1F041CA4124C3B1FFF2F3 /* Button.swift */,
+				1B0AB1F764B8B3C263215AFEFC01143A /* Cell.swift */,
+				9DB84493C64353132E6F27571A43A3F6 /* CollectionView.swift */,
+				D5A869D57AC8EDD0ED0BC6DA6BD96660 /* DatePicker.swift */,
+				5EFFE450A2ED2E1A13F6291EF95C4F19 /* Header.swift */,
+				B99BC68F60289EE3D2B827C55151ED07 /* Icon.swift */,
+				310D0511477295F4E8D3A2CECA4D953A /* Image.swift */,
+				CB2B8E3108E83AEF1A861292D5E667A5 /* Keyboard.swift */,
+				288D4CA144C64E07905184F6CBAAE867 /* Label.swift */,
+				31BB533F397C5D4FD9F1F0910B521877 /* NavBar.swift */,
+				1146247962F18FFC769B180EB17B0A5D /* PageIndicator.swift */,
+				B8F3ADBAFBD856493872E3528629CE26 /* Picker.swift */,
+				D3B5FEA5DCDCA2D582C00DE6B76CDC0B /* ScrollView.swift */,
+				26E0C2DB87953FDF97B668A8BE0A744E /* SecureTextField.swift */,
+				6B82B2F93A1BE5B4C63A8A4CB66E2BE9 /* SegmentedControl.swift */,
+				270FD9B498764D8FEA3F42DB3007EE80 /* Sheet.swift */,
+				97B6600289CF1454BB2B7A95FE5523AB /* Slider.swift */,
+				996EB6D6F78C53D2C9B5D4FBC4C13D84 /* Stepper.swift */,
+				833F3150E7163B9CDD9DC3F6667D24AE /* Switch.swift */,
+				525F300EF39DA23BCE9573EFDF316426 /* TabBar.swift */,
+				0930640B9F785B2533E020EBE1A83252 /* Table.swift */,
+				2E96D37C7B544B5D3F8FABFDB3A65DFD /* TextField.swift */,
+				2BEC99316035011631C40BFCF3197901 /* TextView.swift */,
+				3343170286ADD343A663D64B81BB398B /* View.swift */,
+				B8889DDD0297F197C953F944C127449C /* WebView.swift */,
+			);
+			name = Elements;
+			path = TABTestKit/Classes/Elements;
+			sourceTree = "<group>";
+		};
+		6A7EBFBEC7844CA8D6AD72301695BC6E /* Apps */ = {
+			isa = PBXGroup;
+			children = (
+				D633AFB6915D96D516CD0872E60E2415 /* App.swift */,
+				063860976CBFED0CEABD0E3213F93A8E /* BaseApp.swift */,
+				378BEB1C3B86DE939F26118388E95363 /* Safari.swift */,
+				4A9E2EEC134947F1BCADD81AFCF32A5B /* Springboard.swift */,
+				E4508197147D357E5AC5F92B14089EC1 /* SystemPreferences.swift */,
+			);
+			name = Apps;
+			path = TABTestKit/Classes/Apps;
+			sourceTree = "<group>";
+		};
+		7828C064F857E3C1EAE7C9B73201E07C /* Pod */ = {
+			isa = PBXGroup;
+			children = (
+				E97F64AF467C08D1FB58F73CF59C7EB4 /* LICENSE */,
+				9636ED3E95A98C45C798682289AABB5A /* README.md */,
+				5029125F64A9A19889E338765CD0299E /* TABTestKit.podspec */,
+			);
+			name = Pod;
+			sourceTree = "<group>";
+		};
+		7983087C3129CCABC779E3D0EC3D3BFE /* include */ = {
+			isa = PBXGroup;
+			children = (
+				FBA47936DBE7936C98F0EC94B9E8CEAC /* Biometrics.h */,
+				76351B41B9C4CCADF915B35D11C74EAC /* Biometrics-Bridging-Header.h */,
+			);
+			name = include;
+			path = include;
+			sourceTree = "<group>";
+		};
+		7BBFEA5590048061B9C0E421C6913A22 /* Biometrics */ = {
+			isa = PBXGroup;
+			children = (
+				516FEC36F601143A1A7D9C4483043E02 /* Biometrics.m */,
+				7983087C3129CCABC779E3D0EC3D3BFE /* include */,
 			);
 			name = Biometrics;
 			path = TABTestKit/Classes/Biometrics;
@@ -405,116 +480,24 @@
 			name = Pods;
 			sourceTree = "<group>";
 		};
-		7FD44DEFF2C312F744D47FD7616C45B6 /* Elements */ = {
+		A0704CDE6B94E4F4482FBC2CDDF1C733 /* Protocols */ = {
 			isa = PBXGroup;
 			children = (
-				CC8682021049AEAAB3DCD7C150A95FB2 /* ActivitySheet.swift */,
-				63808F52E6B612D9117EA7F81237AAED /* Alert.swift */,
-				C0E4EAF339F88D5CC4828E58D2D044BA /* Attributes.swift */,
-				8BFD6C0764CD43FFB743CE603C9FFD68 /* Button.swift */,
-				5EE536BF6DFF2331078DBAADAAB49035 /* Cell.swift */,
-				3A6FE0B2CF948C41E54AA50B9A2DBFE6 /* CollectionView.swift */,
-				6980B17C7DE4DADEAE4CC75D703C54AC /* Header.swift */,
-				288348B0E48E8832F351BC7B63303777 /* Icon.swift */,
-				E0A11CCC52D92B046F8A9FA9AC99AF4F /* Image.swift */,
-				37CD9BB357BD4C98594C6FDB2372E203 /* Keyboard.swift */,
-				34B6C40BC468C579D69B2CC4CAF320EC /* Label.swift */,
-				71AC18C8449F986EBB02832E2A07A50F /* NavBar.swift */,
-				8BF44A3860DAFA6F569C7C830A6F42C2 /* PageIndicator.swift */,
-				D07C967D9F11E4E64FCCB0515B63C928 /* Picker.swift */,
-				2EB66BEA4359AD0F6E58CE8E61A7D651 /* ScrollView.swift */,
-				539E3535E6A4796A5DC1359080B1B388 /* SecureTextField.swift */,
-				2120EE906455FB83E2E09406CEF662C9 /* SegmentedControl.swift */,
-				7FDC2516655ADE505B015B6C694D2328 /* Sheet.swift */,
-				71BC30DBECCC085046C14F79A51C96FC /* Slider.swift */,
-				7E675701574C76D0C286A4F6FFFFB5E5 /* Stepper.swift */,
-				A4F037B014CEDE4C8F4E39CB25E05DD2 /* Switch.swift */,
-				1A139CE57C53F627624E7B2244D19E74 /* TabBar.swift */,
-				9089417F0109865CDB124A2329BDD6FB /* Table.swift */,
-				428C7E1FA710CF3CFD6B1D091E8DA215 /* TextField.swift */,
-				A44D97A79485D765FFC1885EF486035C /* TextView.swift */,
-				AB73F3D5CE27BEFC135A72853A578770 /* View.swift */,
-				30B66790D2082BEC84983A6EF4BF5662 /* WebView.swift */,
+				5E1A9256A8DD33C89BAAB57A235F2804 /* Adjustable.swift */,
+				EDF4947C9E27BB97B30F06939F64E9E0 /* CellContaining.swift */,
+				733C9EB16F7A1DF6E9E333F54B511D02 /* Completable.swift */,
+				A3EE8B1C53D5F26ACBFF010AEABAE28B /* Dismissable.swift */,
+				F5D608343740CFA224AF053B57F66F67 /* Editable.swift */,
+				99645CE216E89A6655EC66E732CECD38 /* Element.swift */,
+				0C38F549CCB18E20A90695795AEC5AC6 /* Refreshable.swift */,
+				7EECF51F8060F5B8BFA4281A38586E83 /* Screen.swift */,
+				11F2A3A2A26E9B32CC1F97EE09E1F276 /* Scrollable.swift */,
+				9D132E7F63ED7978B99EF4975197150F /* ScrollableScreen.swift */,
+				E846D1B6D74DE542E5CA9527BD39F15F /* Tappable.swift */,
+				42287AC46DDDC0D1AA7184E181C68C89 /* ValueRepresentable.swift */,
 			);
-			name = Elements;
-			path = TABTestKit/Classes/Elements;
-			sourceTree = "<group>";
-		};
-		84077031334557DE7388627A56AB6D8E /* Contexts */ = {
-			isa = PBXGroup;
-			children = (
-				58701D6FE5B0819E5ECE654224188DC0 /* AlertContext.swift */,
-				5E21D12E79B060EEABD6D9C064FD58DC /* AppContext.swift */,
-				3ABBEEBD584246EF61D103CF1C923A0E /* BiometricsContext.swift */,
-				E34A4D0E90CA84F5B686ECC33E84720D /* InteractionContext.swift */,
-				9428A8F167FEB42DE18A7EBD813A80A5 /* KeyboardContext.swift */,
-				48F3EF5E147F848C915D2D095DFA422D /* NavigationContext.swift */,
-				609F80835D951294E6054EC34BE7DEAB /* SheetContext.swift */,
-				20F6759CD9CFC4C1F5DA6B78EFFBB609 /* SystemPreferencesContext.swift */,
-			);
-			name = Contexts;
-			path = TABTestKit/Classes/Contexts;
-			sourceTree = "<group>";
-		};
-		868B417AD73B1B721B53EAAD193BB43C /* BDD */ = {
-			isa = PBXGroup;
-			children = (
-				D62EEF2B33953AEF764BCFFC3597CF30 /* Scenario.swift */,
-				82E2D18AF412B9ED1E41630009454979 /* Step.swift */,
-			);
-			name = BDD;
-			path = TABTestKit/Classes/BDD;
-			sourceTree = "<group>";
-		};
-		8872C50C8A2611470A75161595B511D1 /* Apps */ = {
-			isa = PBXGroup;
-			children = (
-				17DCECBA4EAAE4C07053D26FBE892D78 /* App.swift */,
-				B6FEDCB8E835BAD94013EC96B36228F2 /* BaseApp.swift */,
-				B10C6E6AABDEF73C8D9E647494F5FFFD /* Safari.swift */,
-				DE2ACC1384856F32BDEAF0B67C4ABBA6 /* Springboard.swift */,
-				2ADFBF8A19DAC2594ED4548F1696E8C9 /* SystemPreferences.swift */,
-			);
-			name = Apps;
-			path = TABTestKit/Classes/Apps;
-			sourceTree = "<group>";
-		};
-		9302C6E69E759D3BC0598249955E45CD /* Pod */ = {
-			isa = PBXGroup;
-			children = (
-				1FEECC2891FA9207E48C23F05FA63331 /* LICENSE */,
-				8A3EB354FF57A4D5DF54965C128B21F6 /* README.md */,
-				43D13F1FAF8603F38A44BA21F33C0912 /* TABTestKit.podspec */,
-			);
-			name = Pod;
-			sourceTree = "<group>";
-		};
-		93861C173157E253A42A264F81336254 /* Screens */ = {
-			isa = PBXGroup;
-			children = (
-				CA36B114B42B335BCF6F8F96ED83733E /* SystemPreferencesGeneralScreen.swift */,
-				0D9B3886BA63D85E95DC7C0E2C41C9C9 /* SystemPreferencesResetScreen.swift */,
-				6AEC6A3A9A1E90D3C5F4B4A736C8E946 /* systemPreferencesRootScreen.swift */,
-			);
-			name = Screens;
-			path = TABTestKit/Classes/Screens;
-			sourceTree = "<group>";
-		};
-		AD21999C0E45239ADD1FC10D908F2545 /* Extensions */ = {
-			isa = PBXGroup;
-			children = (
-				6E78188EC60ABEC11AE165500D2CFFCB /* Array+Safe.swift */,
-				238D94DB52E866485358E8A0DB1C35AF /* CGVector+Offset.swift */,
-				CD37B9C8E065DD3D17F7204B1B1FBD58 /* Element+defaults.swift */,
-				E78108E38AC455729C36C4C7EEDE146C /* NormalizedCoordinate+Locations.swift */,
-				DBE7A8817DB54096950BC6C6163FB2C0 /* XCTFatalFail.swift */,
-				D8F71C696D13A19D07E5810318AA9384 /* XCUIDevice+frame.swift */,
-				CD112D38CB4A7946791170C90730CC9D /* XCUIElement+hasKeyboardFocus.swift */,
-				EC56A10DF2C24631522AEF8CBF30B351 /* XCUIElement+isVisible.swift */,
-				5D9D28DCEEADE9294B60676002E5F3AF /* XCUIElement+wait.swift */,
-			);
-			name = Extensions;
-			path = TABTestKit/Classes/Extensions;
+			name = Protocols;
+			path = TABTestKit/Classes/Protocols;
 			sourceTree = "<group>";
 		};
 		BF4BFAF140349307273B1343616A213B /* Pods-TABTestKit_Example-TABTestKit_ExampleUITests */ = {
@@ -534,6 +517,21 @@
 			path = "Target Support Files/Pods-TABTestKit_Example-TABTestKit_ExampleUITests";
 			sourceTree = "<group>";
 		};
+		C5A671305C6457E83B366DFDC513209E /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				13BA1BD868EA98BFAF1291D67025BC2E /* TABTestKit.modulemap */,
+				76218D3926FC14AD26D4F85F24A78116 /* TABTestKit-dummy.m */,
+				0AF0A2E0D69C6A4EF1AB4402DB0A38EA /* TABTestKit-Info.plist */,
+				D87AACBC58E2252912FEC4132CF481CE /* TABTestKit-prefix.pch */,
+				39F10CDF64864F18B3EEAAE5618F2993 /* TABTestKit-umbrella.h */,
+				10B1611A1B50B1DA5565DB251CBF81F4 /* TABTestKit.debug.xcconfig */,
+				F3F8FE35B25F667403E340317EA9F9FD /* TABTestKit.release.xcconfig */,
+			);
+			name = "Support Files";
+			path = "Example/Pods/Target Support Files/TABTestKit";
+			sourceTree = "<group>";
+		};
 		CF1408CF629C7361332E53B88F7BD30C = {
 			isa = PBXGroup;
 			children = (
@@ -546,29 +544,34 @@
 			);
 			sourceTree = "<group>";
 		};
-		E4AB311632441689EE39961281F1DCDF /* include */ = {
+		D76E1F2CA7E4E47763301BE5EBF14D5C /* Screens */ = {
 			isa = PBXGroup;
 			children = (
-				801D065A67CFE384AC907A0A08A80669 /* Biometrics.h */,
-				825F5BBC95C9AD5A6FEF97516F438976 /* Biometrics-Bridging-Header.h */,
+				EFE83F853FC56745500A916FBFE0BD09 /* SystemPreferencesGeneralScreen.swift */,
+				21A5843633E4D75EE8E1556F939DB746 /* SystemPreferencesResetScreen.swift */,
+				E8D0C69508B528128406927836573B67 /* systemPreferencesRootScreen.swift */,
 			);
-			name = include;
-			path = include;
+			name = Screens;
+			path = TABTestKit/Classes/Screens;
 			sourceTree = "<group>";
 		};
-		ED03717EC67D68756D0CA0452BCCD549 /* Support Files */ = {
+		F6B926016CF4E01F84A53067AEAFC3D1 /* TABTestKit */ = {
 			isa = PBXGroup;
 			children = (
-				8D4D2A880C74185B385459D0F3ECFC51 /* TABTestKit.modulemap */,
-				987BEA52658B9CB88A6F751D324F13AD /* TABTestKit-dummy.m */,
-				96FC8F190C24B476CD216A18EC6FFCF2 /* TABTestKit-Info.plist */,
-				BBE255692AD510B938CB0017AEED4518 /* TABTestKit-prefix.pch */,
-				F00418B0925C8A96D09D1986BE6C1B6B /* TABTestKit-umbrella.h */,
-				5EADE617313EDEFAE09DD75B5F7B1B98 /* TABTestKit.debug.xcconfig */,
-				2139B5533BEBB89B1AAED6BD36926681 /* TABTestKit.release.xcconfig */,
+				C9017D3505D12281FD18FE6120B0A5DE /* TABTestCase.swift */,
+				6A7EBFBEC7844CA8D6AD72301695BC6E /* Apps */,
+				351F0940FBB3A7248B16461D572961DD /* BDD */,
+				7BBFEA5590048061B9C0E421C6913A22 /* Biometrics */,
+				09D33B2E9C4207D5883730B1CC953ACA /* Contexts */,
+				456C8615377475D12A602BADDD74F8AC /* Elements */,
+				2FA8FCAA9775EF55974403A605D05230 /* Extensions */,
+				7828C064F857E3C1EAE7C9B73201E07C /* Pod */,
+				A0704CDE6B94E4F4482FBC2CDDF1C733 /* Protocols */,
+				D76E1F2CA7E4E47763301BE5EBF14D5C /* Screens */,
+				C5A671305C6457E83B366DFDC513209E /* Support Files */,
 			);
-			name = "Support Files";
-			path = "Example/Pods/Target Support Files/TABTestKit";
+			name = TABTestKit;
+			path = ../..;
 			sourceTree = "<group>";
 		};
 		F7FD97F3CC6F18F4AAAE10E5DE0D2076 /* Targets Support Files */ = {
@@ -583,29 +586,29 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
-		1546A71728D546C8D2A345948964F954 /* Headers */ = {
+		0C0F97697811C405610881996CE9A656 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8927BD966BA8175BBCD4A4C1E98EC03C /* Pods-TABTestKit_Example-TABTestKit_ExampleUITests-umbrella.h in Headers */,
+				06F0BA93FE06A8B562D3D88F82D1FF43 /* Biometrics-Bridging-Header.h in Headers */,
+				22AB496E63075EE106F9BA6B4D5CA93A /* Biometrics.h in Headers */,
+				3DDA18D51471D4B5A53CA30FB7A4800E /* TABTestKit-umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		3F40A637A8ECE6C9BDF8E29F37A0BF86 /* Headers */ = {
+		178DFB6B6BAB0C3D7EE913DF5BD7B1F0 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D0A0967C43C505030195B253B82C5E33 /* Biometrics-Bridging-Header.h in Headers */,
-				DCBC7977519A09E364F903C059F52EBF /* Biometrics.h in Headers */,
-				795BE4C0034613920A5C128A01BB53C7 /* TABTestKit-umbrella.h in Headers */,
+				3D53EE53A9983C943A862D0383369B25 /* Pods-TABTestKit_Example-umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		A42B7353448BA3A32CB7E6407B908E88 /* Headers */ = {
+		AB86B7E9D6EAB08392DCE2A1DD93C606 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				74E2F7EA36D277B32C6F922F069AD086 /* Pods-TABTestKit_Example-umbrella.h in Headers */,
+				466B4F15E513602A12E004EE0DDC43EE /* Pods-TABTestKit_Example-TABTestKit_ExampleUITests-umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -622,18 +625,18 @@
 /* Begin PBXNativeTarget section */
 		874D50CB9D57ED75CCA17B703E811C10 /* Pods-TABTestKit_Example-TABTestKit_ExampleUITests */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 067D966EBEDF3E100B9F20252DC91A03 /* Build configuration list for PBXNativeTarget "Pods-TABTestKit_Example-TABTestKit_ExampleUITests" */;
+			buildConfigurationList = D5B2987750CBF4D7AFC2D54182302C16 /* Build configuration list for PBXNativeTarget "Pods-TABTestKit_Example-TABTestKit_ExampleUITests" */;
 			buildPhases = (
-				1546A71728D546C8D2A345948964F954 /* Headers */,
-				00CECBBC3E664D03D81137415A0472A9 /* Sources */,
-				85DE561D3E4964DDC1F5E827216CDF49 /* Frameworks */,
-				C8330D05E85EB6ADF3D4902BF4389D40 /* Resources */,
+				AB86B7E9D6EAB08392DCE2A1DD93C606 /* Headers */,
+				95ECBCD1734887D7515B9A6948AEC029 /* Sources */,
+				C5F45EBFBA89156FDAD636437B27CAAE /* Frameworks */,
+				A7EEE765EE1F67DCB0A455CBABB427F9 /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				29B54EBCF6BDA764E6C123A87DB15DE3 /* PBXTargetDependency */,
-				0075D2073966C32030BEC69EF0AB521A /* PBXTargetDependency */,
+				5881E651165AE9D8ABC7666E58180A86 /* PBXTargetDependency */,
+				8E3FBE2043FCE69E094FCA9E048173C7 /* PBXTargetDependency */,
 			);
 			name = "Pods-TABTestKit_Example-TABTestKit_ExampleUITests";
 			productName = "Pods-TABTestKit_Example-TABTestKit_ExampleUITests";
@@ -642,17 +645,17 @@
 		};
 		97F19241BD426C32C1C3FAF09F17AA80 /* Pods-TABTestKit_Example */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = E466F9F3945C666B20BA45180ECDC7D7 /* Build configuration list for PBXNativeTarget "Pods-TABTestKit_Example" */;
+			buildConfigurationList = 79E6F7CF76BD1BE7D1F1F80FC0ED4DFB /* Build configuration list for PBXNativeTarget "Pods-TABTestKit_Example" */;
 			buildPhases = (
-				A42B7353448BA3A32CB7E6407B908E88 /* Headers */,
-				9D50542E455CC3979D6826F7F6B472DE /* Sources */,
-				434AAE768A8C9EA8DFD951F6ABAC9D5C /* Frameworks */,
-				F6CF63D106363A9CAB47BB8733EBE934 /* Resources */,
+				178DFB6B6BAB0C3D7EE913DF5BD7B1F0 /* Headers */,
+				8A4E3CDF39788C8C58AEFDD62DC67535 /* Sources */,
+				DA6508EB8D221EE762ADFF8A3478C2C9 /* Frameworks */,
+				E29162AAC217F2B0287889DDF6A6DDDE /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				AD551C5862D47EE380A48110BB924316 /* PBXTargetDependency */,
+				09312B6A29165575FE9715A639E3078A /* PBXTargetDependency */,
 			);
 			name = "Pods-TABTestKit_Example";
 			productName = "Pods-TABTestKit_Example";
@@ -679,12 +682,12 @@
 		};
 		9C4F771642E79689CC6A0648ABEA808C /* TABTestKit */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = CCF6C1C87AEA5A4C21DD5400C1FAC792 /* Build configuration list for PBXNativeTarget "TABTestKit" */;
+			buildConfigurationList = 46ECDB4027B6A2823CE01521E3099989 /* Build configuration list for PBXNativeTarget "TABTestKit" */;
 			buildPhases = (
-				3F40A637A8ECE6C9BDF8E29F37A0BF86 /* Headers */,
-				31A42377726E54269592FA374D7C2BCC /* Sources */,
-				FE2EECB8103069FC9D094A9453F0E5E4 /* Frameworks */,
-				B4FE060EE9C101E7883903D02A5DC22F /* Resources */,
+				0C0F97697811C405610881996CE9A656 /* Headers */,
+				EA289E9666BF0769FC14C34FFE0689C0 /* Sources */,
+				4898BC30FDFD419F968119FDEDDF05A7 /* Frameworks */,
+				625FBD6C7BFFC36DD292F6F3A64839A9 /* Resources */,
 			);
 			buildRules = (
 			);
@@ -733,21 +736,21 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		B4FE060EE9C101E7883903D02A5DC22F /* Resources */ = {
+		625FBD6C7BFFC36DD292F6F3A64839A9 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		C8330D05E85EB6ADF3D4902BF4389D40 /* Resources */ = {
+		A7EEE765EE1F67DCB0A455CBABB427F9 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		F6CF63D106363A9CAB47BB8733EBE934 /* Resources */ = {
+		E29162AAC217F2B0287889DDF6A6DDDE /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -757,95 +760,19 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		00CECBBC3E664D03D81137415A0472A9 /* Sources */ = {
+		8A4E3CDF39788C8C58AEFDD62DC67535 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				182CC29C7BAFE0334AC07728900F1D6C /* Pods-TABTestKit_Example-TABTestKit_ExampleUITests-dummy.m in Sources */,
+				178C0B2157C033E8875D33BAFCCD1A07 /* Pods-TABTestKit_Example-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		31A42377726E54269592FA374D7C2BCC /* Sources */ = {
+		95ECBCD1734887D7515B9A6948AEC029 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7BE3CA364825F8CD761A911CA29DEC00 /* ActivitySheet.swift in Sources */,
-				31D832E6B1905EB24BD3914FB9E4E26D /* Adjustable.swift in Sources */,
-				64BAD1DD1EA45B92B9AFF98CE73A5ED4 /* Alert.swift in Sources */,
-				6972944BAF55F67D1613B40566B51B59 /* AlertContext.swift in Sources */,
-				B513DE81DB5A4FF5CB34A166242B6A1B /* App.swift in Sources */,
-				863EE3A68BBD9D64B35BD86403CFE347 /* AppContext.swift in Sources */,
-				EA26D3491AF4F16202B2F0B5A231CCD8 /* Array+Safe.swift in Sources */,
-				5D7A82AD1AFEF42A0E95D96C466A99E6 /* Attributes.swift in Sources */,
-				58810327410B85FEB119763254AA4B0B /* BaseApp.swift in Sources */,
-				AE85E79E4A1CB7C55A422C5B8095547F /* Biometrics.m in Sources */,
-				430AC0E3784C452CA9A861D9E6AC9E46 /* BiometricsContext.swift in Sources */,
-				07FDD88F73EA8960D0F9E3C3EF4B6E4E /* Button.swift in Sources */,
-				B37EC5CB2875EB4529A536911F8660EE /* Cell.swift in Sources */,
-				4B8A6E15476B0C9F6CBC5F274DE4FC7C /* CellContaining.swift in Sources */,
-				6976C71365844907D1C897F35DF571C4 /* CGVector+Offset.swift in Sources */,
-				B689E311677718EBC18E8A65181E28D1 /* CollectionView.swift in Sources */,
-				1C9C381CC36794C97A0D5856A243AECA /* Completable.swift in Sources */,
-				930BB84CB3CD91D6C3F47344F1E3B716 /* Dismissable.swift in Sources */,
-				320CD0432837527FF659853E14CCE0EB /* Editable.swift in Sources */,
-				A1DEEA086571A976344EACF308E8B05C /* Element+defaults.swift in Sources */,
-				DB455946D47F73E2186787172F680213 /* Element.swift in Sources */,
-				3FFB5CEAF0482B2CC8FA486FAFE32A62 /* Header.swift in Sources */,
-				BB77F7A6807B6E204739EB0881E3B4CA /* Icon.swift in Sources */,
-				8BB6FAEAAE345666BA4D0339B6512DA6 /* Image.swift in Sources */,
-				C5CD0C3F1C611A6F4C44A5752E91C2F5 /* InteractionContext.swift in Sources */,
-				F259DC0C2C71FE4DE5FAAD5C376C0601 /* Keyboard.swift in Sources */,
-				87219A0833E2C2DB62240B62D31BCB17 /* KeyboardContext.swift in Sources */,
-				9BB4E051EA402E2BFC9EC5D111B197FF /* Label.swift in Sources */,
-				6E077301C2429F6C0F506EC83BFCDCB3 /* NavBar.swift in Sources */,
-				59C61F9D86B646893D50711CC5C6801A /* NavigationContext.swift in Sources */,
-				743F40249F12DD773D943A66974214F9 /* NormalizedCoordinate+Locations.swift in Sources */,
-				64014F0876F2797A9BA0548CF916D20B /* PageIndicator.swift in Sources */,
-				0B68E89B98365D41A7600239B2092EDD /* Picker.swift in Sources */,
-				B36FC689297C3EE65EB22BA68CD71863 /* Refreshable.swift in Sources */,
-				E7FB14F2DBF5C8E23887E8D7E4D0FA33 /* Safari.swift in Sources */,
-				31E317402DD57DCD01147DD5A1B03793 /* Scenario.swift in Sources */,
-				C997CEF610E3041E1C3A5E95D08932B7 /* Screen.swift in Sources */,
-				80A3AB6B2D68A0FE6AD65D9E406C0610 /* Scrollable.swift in Sources */,
-				57001A8096851FD8002D6A76EE216715 /* ScrollableScreen.swift in Sources */,
-				B7CF969CE6C43590EF1C83A67707912A /* ScrollView.swift in Sources */,
-				2A7568FFE5FC98F3A8A8C9EC2E6CFBBA /* SecureTextField.swift in Sources */,
-				1CAD5E52058606696556F9E164DC8D5D /* SegmentedControl.swift in Sources */,
-				0D0CA421CAB8CFB002F3A7958428F87D /* Sheet.swift in Sources */,
-				A491165E101133259FF943950187B759 /* SheetContext.swift in Sources */,
-				23FED18C864803B6CD493F0DED90E82B /* Slider.swift in Sources */,
-				11661C36C0918639523AE19766D96ADB /* Springboard.swift in Sources */,
-				7FC59073193FDD929E3C7DF6C5F7DAC8 /* Step.swift in Sources */,
-				859F328E4ABF338A9987E4A2A835B5D2 /* Stepper.swift in Sources */,
-				96F4D54DC6D19C2B62038FB29CA14EFC /* Switch.swift in Sources */,
-				D9D0A3DCC7BEB64B8F1602523BA266E4 /* SystemPreferences.swift in Sources */,
-				BD175ABDA60A025E76859EC888C936CB /* SystemPreferencesContext.swift in Sources */,
-				84207533D404FF5E0399A8E25C9E54B1 /* SystemPreferencesGeneralScreen.swift in Sources */,
-				57ED8608C9256BFEE6338B4D9C6BA3D2 /* SystemPreferencesResetScreen.swift in Sources */,
-				A42C4B780986976455B79A6DCE9DA9E2 /* systemPreferencesRootScreen.swift in Sources */,
-				E434A53EF6A44B1AE884F2B627B29B32 /* TabBar.swift in Sources */,
-				1090D87A7D515D6D41D894DD759E7A5F /* Table.swift in Sources */,
-				1B1415B0B3DB73411748BF869920A0F2 /* TABTestCase.swift in Sources */,
-				747122308EDDFEF93EF4E728E15CF1F6 /* TABTestKit-dummy.m in Sources */,
-				208D7E4CF6D5816E2375BD8E79E45004 /* Tappable.swift in Sources */,
-				B4C82C8ACF0F022053310C472E055B93 /* TextField.swift in Sources */,
-				4101E143EB6E39F850E73276237625DD /* TextView.swift in Sources */,
-				A0CB99B9EA85274E99D1FA593199CFE0 /* ValueRepresentable.swift in Sources */,
-				63D3C37B825C72FC8B554ECEF6A1C189 /* View.swift in Sources */,
-				FDA563324A4D72C0C284BEF9380A869C /* WebView.swift in Sources */,
-				63EA29EA99DA5C624B186F7CD629B14D /* XCTFatalFail.swift in Sources */,
-				BC63BDE0255954A2DA44B3F1D90E30D1 /* XCUIDevice+frame.swift in Sources */,
-				5B39540A604873FB3180D8B28B8B88FA /* XCUIElement+hasKeyboardFocus.swift in Sources */,
-				D0FD68BBEC62BB6F4DB4D2F58E269A44 /* XCUIElement+isVisible.swift in Sources */,
-				280DE7E704E54040AAD99A912D804B1C /* XCUIElement+wait.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		9D50542E455CC3979D6826F7F6B472DE /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				7E7556B81F678C3A6E6580D9039C676A /* Pods-TABTestKit_Example-dummy.m in Sources */,
+				EE7661A93B9C6E26F9D8C1D89491F76E /* Pods-TABTestKit_Example-TABTestKit_ExampleUITests-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -858,26 +785,103 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		EA289E9666BF0769FC14C34FFE0689C0 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				037438E458F376D3ED3311C9C9C424D1 /* ActivitySheet.swift in Sources */,
+				94D870EB04EAD571F26204DFA1DE5BF8 /* Adjustable.swift in Sources */,
+				1EEECE824542B4516057559E98B80E1C /* Alert.swift in Sources */,
+				B169B20C039E782186565E2E52ACB787 /* AlertContext.swift in Sources */,
+				24D51ED262D69888D4892E35D4B296B1 /* App.swift in Sources */,
+				965F572E8A4577F5564E718B08CA0DEC /* AppContext.swift in Sources */,
+				E11FF4E3610B51833B5B25BFEC9439EB /* Array+Safe.swift in Sources */,
+				67BDAF48BC71ADD6FFBD9BC3F60CC489 /* Attributes.swift in Sources */,
+				C45F1CA24939CFC0EA011576B184E517 /* BaseApp.swift in Sources */,
+				C28393A7BA4949E7EC11BA68290E0A89 /* Biometrics.m in Sources */,
+				672CCDA6A5E3879637348218DCC4A967 /* BiometricsContext.swift in Sources */,
+				1FDB0E9D01FF2441B2C4BFDB3367E927 /* Button.swift in Sources */,
+				7E50C1883D363FEBF04C6B1F0D12E834 /* Cell.swift in Sources */,
+				56D50EAF7965D5AE0E5181A61398C2FE /* CellContaining.swift in Sources */,
+				F19E657512049CDD2FD1414E408073C8 /* CGVector+Offset.swift in Sources */,
+				84B1885DB2D83AFD090C3CCCA8472C4E /* CollectionView.swift in Sources */,
+				707000A4026440BF85F559F095DEB890 /* Completable.swift in Sources */,
+				030C8476D8BE89065E5328E67EF56752 /* DatePicker.swift in Sources */,
+				6D14253BA9582C897106391DA95677C5 /* Dismissable.swift in Sources */,
+				073BB799FC643900737132A1DAC712C1 /* Editable.swift in Sources */,
+				F67B7C7FDE9074CDCFA68E004947AA92 /* Element+defaults.swift in Sources */,
+				A41B5CCF42789157090E258FE089586C /* Element.swift in Sources */,
+				6BEE0D6E2E2AB96DD64F04F9B4C33B2D /* Header.swift in Sources */,
+				25CB8336A1F82DDC9CD5005EFBB7F29B /* Icon.swift in Sources */,
+				FB1E11C5834A94EA4E92203A824C7712 /* Image.swift in Sources */,
+				205F7DF3026977DA94FAC59A3D0B9F32 /* InteractionContext.swift in Sources */,
+				EBD37C76644005FA6D30F6FCAA57EA58 /* Keyboard.swift in Sources */,
+				1CF73984D3297083B164E8AFDFB68A9D /* KeyboardContext.swift in Sources */,
+				DA63CBAA1FD4B0B8D56B351BC7B277F4 /* Label.swift in Sources */,
+				74FE7D271C05B5F5CF16CD40289ED053 /* NavBar.swift in Sources */,
+				1F4FEC3156C65D28F6B9458BD75E2F88 /* NavigationContext.swift in Sources */,
+				E09FEFAFFD39157648FFABB51E2EB3EA /* NormalizedCoordinate+Locations.swift in Sources */,
+				697DDFCEB90BB157DB000D322CD19D5C /* PageIndicator.swift in Sources */,
+				B355BFBF02732C2EFDFCC79CE84DBEEF /* Picker.swift in Sources */,
+				C9939C0BDAD41AA1F33BE52342C396FB /* Refreshable.swift in Sources */,
+				D83B7250A5C7CDFE4F64E0EEDD639892 /* Safari.swift in Sources */,
+				FB0F482C6EC685FC996684E7E0C58A81 /* Scenario.swift in Sources */,
+				1769E66936A8148901759A505D1134D8 /* Screen.swift in Sources */,
+				B3F91A927D31FD30CAE8C721D3CDD916 /* Scrollable.swift in Sources */,
+				297A89E5D9EA42B0F082560478BD138D /* ScrollableScreen.swift in Sources */,
+				981319D676A5ECFF485A539211C464A2 /* ScrollView.swift in Sources */,
+				CE96ADAED2FDB8BB47A327A08562475C /* SecureTextField.swift in Sources */,
+				11278B65581A09C350D0FE282C241B2F /* SegmentedControl.swift in Sources */,
+				7FF9CA487AB366CCB8F77DD7B22AB8F4 /* Sheet.swift in Sources */,
+				AE182ECBB0181991D6E601FF083869A3 /* SheetContext.swift in Sources */,
+				481F82DB88069C6B92FF1778580B39F6 /* Slider.swift in Sources */,
+				E558577851F19778E543AE6D7DCFF30A /* Springboard.swift in Sources */,
+				D8771E317705B1A18BFDE9E3C391EF7F /* Step.swift in Sources */,
+				E3AA3BD0B36A8D7D0DDADCA23C123130 /* Stepper.swift in Sources */,
+				232838548112A58B1405F1649A3C8D5A /* Switch.swift in Sources */,
+				4CF2489EF04BC5D95D8CC7B883F8F136 /* SystemPreferences.swift in Sources */,
+				0E61D42891FE5FEC32F4F79B64A0A31A /* SystemPreferencesContext.swift in Sources */,
+				96CF87699933D48A91FDD92BBBBD3A96 /* SystemPreferencesGeneralScreen.swift in Sources */,
+				145EF16BC9E3275A3BE2EA2E24CCC25B /* SystemPreferencesResetScreen.swift in Sources */,
+				214C5AC2BEB372773B81A89E3CA9649E /* systemPreferencesRootScreen.swift in Sources */,
+				B390F02F5BF0E704C2530E6B864C8DA4 /* TabBar.swift in Sources */,
+				8722F7FE01B09905CE43F5FE2F84E4AB /* Table.swift in Sources */,
+				723BE432EFB0A62753F492943A3A67B4 /* TABTestCase.swift in Sources */,
+				B958E7CE0D4615F3F9D93D4E33F4DF36 /* TABTestKit-dummy.m in Sources */,
+				6693CC10486D411C5AEE771A4DED0AB4 /* Tappable.swift in Sources */,
+				C5E46852D59375EE4308956FD7ACADE6 /* TextField.swift in Sources */,
+				E9BA1D90C07B623069A2D6BB1686441B /* TextView.swift in Sources */,
+				F566D30798059D2B906BF3245752870F /* ValueRepresentable.swift in Sources */,
+				E87367920E610653998714517B01869C /* View.swift in Sources */,
+				6FB96E7AE7560CFFE96A83D5A2B9FFC9 /* WebView.swift in Sources */,
+				9D1D06B968FEF34BEFBC5DA3B5F211A3 /* XCTFatalFail.swift in Sources */,
+				22824B0B33B4C8170ED1DE4ABC96A61A /* XCUIDevice+frame.swift in Sources */,
+				D86774E04E3EAF51A19C123A7D21000A /* XCUIElement+hasKeyboardFocus.swift in Sources */,
+				9914EC8EA7D7B376F4F8046D2F5A8380 /* XCUIElement+isVisible.swift in Sources */,
+				4D991C4CAEF57EB28E0F107BCBCC5464 /* XCUIElement+wait.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		0075D2073966C32030BEC69EF0AB521A /* PBXTargetDependency */ = {
+		09312B6A29165575FE9715A639E3078A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = ShowTime;
+			target = 9C1FEFBBC00DBFB4EC56C99126E8E9B0 /* ShowTime */;
+			targetProxy = 08A99BEA9208FCFDB1062DADA9B40487 /* PBXContainerItemProxy */;
+		};
+		5881E651165AE9D8ABC7666E58180A86 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = ShowTime;
+			target = 9C1FEFBBC00DBFB4EC56C99126E8E9B0 /* ShowTime */;
+			targetProxy = 34A9B585AC52D00944BC81029C8F615A /* PBXContainerItemProxy */;
+		};
+		8E3FBE2043FCE69E094FCA9E048173C7 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = TABTestKit;
 			target = 9C4F771642E79689CC6A0648ABEA808C /* TABTestKit */;
-			targetProxy = 04C0ED95764AD70BF43EFA78B032313B /* PBXContainerItemProxy */;
-		};
-		29B54EBCF6BDA764E6C123A87DB15DE3 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = ShowTime;
-			target = 9C1FEFBBC00DBFB4EC56C99126E8E9B0 /* ShowTime */;
-			targetProxy = 0BF10D5355C2C44AED2A9D0480F98BF0 /* PBXContainerItemProxy */;
-		};
-		AD551C5862D47EE380A48110BB924316 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = ShowTime;
-			target = 9C1FEFBBC00DBFB4EC56C99126E8E9B0 /* ShowTime */;
-			targetProxy = 5E46CC12080B1A9E37FBD7588D02584F /* PBXContainerItemProxy */;
+			targetProxy = F598D08DAB210C6E35AA46DCC7485897 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -914,9 +918,9 @@
 			};
 			name = Debug;
 		};
-		0BFA6A1F08DB617ED88EA69685ABDDE4 /* Release */ = {
+		4AA9A6590BE6067B119FD29AD22BC1DA /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 965A292F186CF36A47FF8AB1CADE1B85 /* Pods-TABTestKit_Example-TABTestKit_ExampleUITests.release.xcconfig */;
+			baseConfigurationReference = 14146CA31421B9CAE5A93C48F6E9FFAF /* Pods-TABTestKit_Example.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
@@ -930,12 +934,12 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = "Target Support Files/Pods-TABTestKit_Example-TABTestKit_ExampleUITests/Pods-TABTestKit_Example-TABTestKit_ExampleUITests-Info.plist";
+				INFOPLIST_FILE = "Target Support Files/Pods-TABTestKit_Example/Pods-TABTestKit_Example-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MACH_O_TYPE = staticlib;
-				MODULEMAP_FILE = "Target Support Files/Pods-TABTestKit_Example-TABTestKit_ExampleUITests/Pods-TABTestKit_Example-TABTestKit_ExampleUITests.modulemap";
+				MODULEMAP_FILE = "Target Support Files/Pods-TABTestKit_Example/Pods-TABTestKit_Example.modulemap";
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PODS_ROOT = "$(SRCROOT)";
@@ -943,6 +947,39 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		5461FC43C9BCAC3590847BBEA1352C97 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = F3F8FE35B25F667403E340317EA9F9FD /* TABTestKit.release.xcconfig */;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/TABTestKit/TABTestKit-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/TABTestKit/TABTestKit-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/TABTestKit/TABTestKit.modulemap";
+				PRODUCT_MODULE_NAME = TABTestKit;
+				PRODUCT_NAME = TABTestKit;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -1014,9 +1051,9 @@
 			};
 			name = Debug;
 		};
-		7B8B0B183596E59238D618A15FFBF496 /* Release */ = {
+		648819B546FFE3C9C27567423DC890F6 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = AFD57256DAD4C8414BD38FD34982C7B0 /* Pods-TABTestKit_Example.release.xcconfig */;
+			baseConfigurationReference = FDC54A8EC562A73143E238094E80179D /* Pods-TABTestKit_Example-TABTestKit_ExampleUITests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
@@ -1030,12 +1067,12 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = "Target Support Files/Pods-TABTestKit_Example/Pods-TABTestKit_Example-Info.plist";
+				INFOPLIST_FILE = "Target Support Files/Pods-TABTestKit_Example-TABTestKit_ExampleUITests/Pods-TABTestKit_Example-TABTestKit_ExampleUITests-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MACH_O_TYPE = staticlib;
-				MODULEMAP_FILE = "Target Support Files/Pods-TABTestKit_Example/Pods-TABTestKit_Example.modulemap";
+				MODULEMAP_FILE = "Target Support Files/Pods-TABTestKit_Example-TABTestKit_ExampleUITests/Pods-TABTestKit_Example-TABTestKit_ExampleUITests.modulemap";
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PODS_ROOT = "$(SRCROOT)";
@@ -1044,11 +1081,10 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
-			name = Release;
+			name = Debug;
 		};
 		9C013AE42837DDBED81C8A67FA1E1264 /* Release */ = {
 			isa = XCBuildConfiguration;
@@ -1143,9 +1179,9 @@
 			};
 			name = Release;
 		};
-		A6CE0683F803CFA02777A77FDC2CA534 /* Release */ = {
+		B5CE3F147104D954E37FBE9577891D2E /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2139B5533BEBB89B1AAED6BD36926681 /* TABTestKit.release.xcconfig */;
+			baseConfigurationReference = 10B1611A1B50B1DA5565DB251CBF81F4 /* TABTestKit.debug.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
@@ -1171,50 +1207,14 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		C3C3A1E9CBD3ACA59EE6FEB79CB855BF /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 14146CA31421B9CAE5A93C48F6E9FFAF /* Pods-TABTestKit_Example.debug.xcconfig */;
-			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
-				CLANG_ENABLE_OBJC_WEAK = NO;
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = "Target Support Files/Pods-TABTestKit_Example/Pods-TABTestKit_Example-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MACH_O_TYPE = staticlib;
-				MODULEMAP_FILE = "Target Support Files/Pods-TABTestKit_Example/Pods-TABTestKit_Example.modulemap";
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
 			name = Debug;
 		};
-		CE151341453F4E20E4C42D1306D5AC47 /* Debug */ = {
+		C146F080B54211E12596F1567C627B35 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = FDC54A8EC562A73143E238094E80179D /* Pods-TABTestKit_Example-TABTestKit_ExampleUITests.debug.xcconfig */;
+			baseConfigurationReference = 965A292F186CF36A47FF8AB1CADE1B85 /* Pods-TABTestKit_Example-TABTestKit_ExampleUITests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
@@ -1242,15 +1242,17 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
-			name = Debug;
+			name = Release;
 		};
-		DE5ABB1E367ED2B2430D53D7693DB72A /* Debug */ = {
+		FD5F6DC5A1972D95AB74B8893C7F13BD /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5EADE617313EDEFAE09DD75B5F7B1B98 /* TABTestKit.debug.xcconfig */;
+			baseConfigurationReference = AFD57256DAD4C8414BD38FD34982C7B0 /* Pods-TABTestKit_Example.release.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_IDENTITY = "";
@@ -1262,41 +1264,43 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/TABTestKit/TABTestKit-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/TABTestKit/TABTestKit-Info.plist";
+				INFOPLIST_FILE = "Target Support Files/Pods-TABTestKit_Example/Pods-TABTestKit_Example-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/TABTestKit/TABTestKit.modulemap";
-				PRODUCT_MODULE_NAME = TABTestKit;
-				PRODUCT_NAME = TABTestKit;
+				MACH_O_TYPE = staticlib;
+				MODULEMAP_FILE = "Target Support Files/Pods-TABTestKit_Example/Pods-TABTestKit_Example.modulemap";
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
-			name = Debug;
+			name = Release;
 		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		067D966EBEDF3E100B9F20252DC91A03 /* Build configuration list for PBXNativeTarget "Pods-TABTestKit_Example-TABTestKit_ExampleUITests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				CE151341453F4E20E4C42D1306D5AC47 /* Debug */,
-				0BFA6A1F08DB617ED88EA69685ABDDE4 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
 		13338E6A92763276D7E744F0BE126971 /* Build configuration list for PBXNativeTarget "ShowTime" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				040B3C23F3536587D5A4EB91C89D63A1 /* Debug */,
 				9C013AE42837DDBED81C8A67FA1E1264 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		46ECDB4027B6A2823CE01521E3099989 /* Build configuration list for PBXNativeTarget "TABTestKit" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B5CE3F147104D954E37FBE9577891D2E /* Debug */,
+				5461FC43C9BCAC3590847BBEA1352C97 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -1310,20 +1314,20 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		CCF6C1C87AEA5A4C21DD5400C1FAC792 /* Build configuration list for PBXNativeTarget "TABTestKit" */ = {
+		79E6F7CF76BD1BE7D1F1F80FC0ED4DFB /* Build configuration list for PBXNativeTarget "Pods-TABTestKit_Example" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				DE5ABB1E367ED2B2430D53D7693DB72A /* Debug */,
-				A6CE0683F803CFA02777A77FDC2CA534 /* Release */,
+				4AA9A6590BE6067B119FD29AD22BC1DA /* Debug */,
+				FD5F6DC5A1972D95AB74B8893C7F13BD /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		E466F9F3945C666B20BA45180ECDC7D7 /* Build configuration list for PBXNativeTarget "Pods-TABTestKit_Example" */ = {
+		D5B2987750CBF4D7AFC2D54182302C16 /* Build configuration list for PBXNativeTarget "Pods-TABTestKit_Example-TABTestKit_ExampleUITests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				C3C3A1E9CBD3ACA59EE6FEB79CB855BF /* Debug */,
-				7B8B0B183596E59238D618A15FFBF496 /* Release */,
+				648819B546FFE3C9C27567423DC890F6 /* Debug */,
+				C146F080B54211E12596F1567C627B35 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Example/TABTestKit.xcodeproj/xcshareddata/xcschemes/TABTestKit-Example.xcscheme
+++ b/Example/TABTestKit.xcodeproj/xcshareddata/xcschemes/TABTestKit-Example.xcscheme
@@ -60,6 +60,13 @@
             ReferencedContainer = "container:TABTestKit.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "TZ"
+            value = "UTC"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Example/TABTestKit/Base.lproj/Main.storyboard
+++ b/Example/TABTestKit/Base.lproj/Main.storyboard
@@ -288,24 +288,24 @@
                                                     </pickerView>
                                                     <datePicker contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="time" minuteInterval="1" useCurrentDate="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4as-Ma-a4Q">
                                                         <rect key="frame" x="0.0" y="1121.5" width="311" height="216"/>
-                                                        <date key="date" timeIntervalSinceReferenceDate="618997260.29273796">
-                                                            <!--2020-08-13 07:41:00 +0000-->
+                                                        <date key="date" timeIntervalSinceReferenceDate="619000860.29273796">
+                                                            <!--2020-08-13 08:41:00 +0000-->
                                                         </date>
                                                     </datePicker>
                                                     <datePicker contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="date" useCurrentDate="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wph-qF-GtI">
                                                         <rect key="frame" x="0.0" y="1353.5" width="311" height="216"/>
-                                                        <date key="date" timeIntervalSinceReferenceDate="190024860.60229194">
-                                                            <!--2007-01-09 08:41:00 +0000-->
+                                                        <date key="date" timeIntervalSinceReferenceDate="190028460.60229194">
+                                                            <!--2007-01-09 09:41:00 +0000-->
                                                         </date>
                                                     </datePicker>
                                                     <datePicker contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="dateAndTime" minuteInterval="1" useCurrentDate="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fRz-H3-Gl2">
-                                                        <rect key="frame" x="0.0" y="1585" width="311" height="216"/>
-                                                        <date key="date" timeIntervalSinceReferenceDate="190024860.30715942">
-                                                            <!--2007-01-09 08:41:00 +0000-->
+                                                        <rect key="frame" x="0.0" y="1585.5" width="311" height="216"/>
+                                                        <date key="date" timeIntervalSinceReferenceDate="190028460.30715942">
+                                                            <!--2007-01-09 09:41:00 +0000-->
                                                         </date>
                                                     </datePicker>
                                                     <datePicker contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="countDownTimer" minuteInterval="1" useCurrentDate="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2Aw-hZ-e5N">
-                                                        <rect key="frame" x="0.0" y="1817" width="311" height="216"/>
+                                                        <rect key="frame" x="0.0" y="1817.5" width="311" height="216"/>
                                                     </datePicker>
                                                 </subviews>
                                             </stackView>

--- a/Example/TABTestKit/Base.lproj/Main.storyboard
+++ b/Example/TABTestKit/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="VEl-fI-I9x">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="VEl-fI-I9x">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -163,7 +163,7 @@
                                         <rect key="frame" x="0.0" y="0.0" width="375" height="1075.5"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="ZkC-Ik-w7v">
-                                                <rect key="frame" x="32" y="8" width="311" height="1105.5"/>
+                                                <rect key="frame" x="32" y="8" width="311" height="2033.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Example label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="T3E-u4-09J">
                                                         <rect key="frame" x="0.0" y="0.0" width="311" height="20.5"/>
@@ -247,6 +247,9 @@
                                                         <rect key="frame" x="0.0" y="579.5" width="311" height="34"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                         <textInputTraits key="textInputTraits" secureTextEntry="YES"/>
+                                                        <connections>
+                                                            <outlet property="delegate" destination="jT9-QJ-sAL" id="dmw-QK-hwI"/>
+                                                        </connections>
                                                     </textField>
                                                     <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="0.5" minValue="0.0" maxValue="1" translatesAutoresizingMaskIntoConstraints="NO" id="iym-dm-QHe">
                                                         <rect key="frame" x="-2" y="629.5" width="315" height="31"/>
@@ -283,6 +286,27 @@
                                                     <pickerView contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ufc-9Z-WSb">
                                                         <rect key="frame" x="0.0" y="889.5" width="311" height="216"/>
                                                     </pickerView>
+                                                    <datePicker contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="time" minuteInterval="1" useCurrentDate="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4as-Ma-a4Q">
+                                                        <rect key="frame" x="0.0" y="1121.5" width="311" height="216"/>
+                                                        <date key="date" timeIntervalSinceReferenceDate="618997260.29273796">
+                                                            <!--2020-08-13 07:41:00 +0000-->
+                                                        </date>
+                                                    </datePicker>
+                                                    <datePicker contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="date" useCurrentDate="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wph-qF-GtI">
+                                                        <rect key="frame" x="0.0" y="1353.5" width="311" height="216"/>
+                                                        <date key="date" timeIntervalSinceReferenceDate="190024860.60229194">
+                                                            <!--2007-01-09 08:41:00 +0000-->
+                                                        </date>
+                                                    </datePicker>
+                                                    <datePicker contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="dateAndTime" minuteInterval="1" useCurrentDate="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fRz-H3-Gl2">
+                                                        <rect key="frame" x="0.0" y="1585" width="311" height="216"/>
+                                                        <date key="date" timeIntervalSinceReferenceDate="190024860.30715942">
+                                                            <!--2007-01-09 08:41:00 +0000-->
+                                                        </date>
+                                                    </datePicker>
+                                                    <datePicker contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="countDownTimer" minuteInterval="1" useCurrentDate="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2Aw-hZ-e5N">
+                                                        <rect key="frame" x="0.0" y="1817" width="311" height="216"/>
+                                                    </datePicker>
                                                 </subviews>
                                             </stackView>
                                         </subviews>
@@ -316,6 +340,9 @@
                     <navigationItem key="navigationItem" title="Other elements" largeTitleDisplayMode="always" id="O65-53-ThR"/>
                     <connections>
                         <outlet property="button" destination="qtX-qz-K6y" id="uki-Ua-0gn"/>
+                        <outlet property="countDownTimerPicker" destination="2Aw-hZ-e5N" id="Zff-xn-KrB"/>
+                        <outlet property="datePicker" destination="wph-qF-GtI" id="gw9-Yw-OSC"/>
+                        <outlet property="dateTimePicker" destination="fRz-H3-Gl2" id="Vwa-gE-gbI"/>
                         <outlet property="decimalPadTextField" destination="61Z-cm-ZHi" id="erp-Pq-mkz"/>
                         <outlet property="emailAddressTextField" destination="5fw-xl-ecR" id="8yG-pC-ARd"/>
                         <outlet property="imageView" destination="Qez-OB-CWf" id="3ih-0H-8Kj"/>
@@ -332,6 +359,7 @@
                         <outlet property="slider" destination="iym-dm-QHe" id="NU5-AN-iJ9"/>
                         <outlet property="stepper" destination="QXt-TJ-bdf" id="A17-Li-ccK"/>
                         <outlet property="textField" destination="bRG-zE-qHL" id="PdM-On-Yda"/>
+                        <outlet property="timePicker" destination="4as-Ma-a4Q" id="ea2-Gl-csL"/>
                         <outlet property="toggle" destination="gl3-Sg-afe" id="WtL-Ho-YyF"/>
                         <outlet property="twitterTextField" destination="y4q-2w-08a" id="FVh-Tb-IlO"/>
                         <outlet property="urlTextField" destination="A4H-hn-Yns" id="hOL-8g-sui"/>

--- a/Example/TABTestKit/Base.lproj/Main.storyboard
+++ b/Example/TABTestKit/Base.lproj/Main.storyboard
@@ -288,8 +288,8 @@
                                                     </pickerView>
                                                     <datePicker contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="time" minuteInterval="1" useCurrentDate="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4as-Ma-a4Q">
                                                         <rect key="frame" x="0.0" y="1121.5" width="311" height="216"/>
-                                                        <date key="date" timeIntervalSinceReferenceDate="619000860.29273796">
-                                                            <!--2020-08-13 08:41:00 +0000-->
+                                                        <date key="date" timeIntervalSinceReferenceDate="619004460.29273796">
+                                                            <!--2020-08-13 09:41:00 +0000-->
                                                         </date>
                                                     </datePicker>
                                                     <datePicker contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="date" useCurrentDate="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wph-qF-GtI">

--- a/Example/TABTestKit/OtherElementsController.swift
+++ b/Example/TABTestKit/OtherElementsController.swift
@@ -78,6 +78,7 @@ final class OtherElementsController: UIViewController {
 extension OtherElementsController: UITextFieldDelegate {
   func textFieldShouldReturn(_ textField: UITextField) -> Bool {
     textField.resignFirstResponder()
+    return true
   }
 }
 

--- a/Example/TABTestKit/OtherElementsController.swift
+++ b/Example/TABTestKit/OtherElementsController.swift
@@ -33,7 +33,11 @@ final class OtherElementsController: UIViewController {
   @IBOutlet private var pageControl: UIPageControl!
   @IBOutlet private var imageView: UIImageView!
   @IBOutlet private var picker: UIPickerView!
-  
+  @IBOutlet private var timePicker: UIDatePicker!
+  @IBOutlet private var datePicker: UIDatePicker!
+  @IBOutlet private var dateTimePicker: UIDatePicker!
+  @IBOutlet private var countDownTimerPicker: UIDatePicker!
+
   override func viewDidLoad() {
     super.viewDidLoad()
     scrollView.accessibilityIdentifier = "MyScrollView"
@@ -58,6 +62,10 @@ final class OtherElementsController: UIViewController {
     picker.accessibilityIdentifier = "ExamplePicker"
     picker.dataSource = self
     picker.delegate = self
+    timePicker.accessibilityIdentifier = "ExampleTimePicker"
+    datePicker.accessibilityIdentifier = "ExampleDatePicker"
+    dateTimePicker.accessibilityIdentifier = "ExampleDateTimePicker"
+    countDownTimerPicker.accessibilityIdentifier = "ExampleCountDownTimerPicker"
   }
   
   @IBAction private func buttonTapped() {
@@ -65,6 +73,12 @@ final class OtherElementsController: UIViewController {
     present(sheet, animated: true)
   }
   
+}
+
+extension OtherElementsController: UITextFieldDelegate {
+  func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+    textField.resignFirstResponder()
+  }
 }
 
 extension OtherElementsController: UIPickerViewDataSource & UIPickerViewDelegate {

--- a/Example/TABTestKit_ExampleUITests/OtherElementsScreen.swift
+++ b/Example/TABTestKit_ExampleUITests/OtherElementsScreen.swift
@@ -33,6 +33,10 @@ struct OtherElementsScreen: Screen {
     let pageIndicator = PageIndicator(id: "ExamplePageControl")
     let image = Image(id: "ExampleImage")
     let picker = Picker(id: "ExamplePicker")
+    let timePicker = DatePicker(id: "ExampleTimePicker")
+    let datePicker = DatePicker(id: "ExampleDatePicker")
+    let dateTimePicker = DatePicker(id: "ExampleDateTimePicker")
+    let countdownTimerPicker = DatePicker(id: "ExampleCountDownTimerPicker")
     let shareSheet = ActivitySheet()
     
 }

--- a/Example/TABTestKit_ExampleUITests/OtherElementsTests.swift
+++ b/Example/TABTestKit_ExampleUITests/OtherElementsTests.swift
@@ -125,7 +125,8 @@ final class OtherElementsTests: TABTestCase, SystemPreferencesContext {
         }
         
         Scenario("Seeing and interacting with the slider") {
-            Given(I: see(otherElementsScreen.slider))
+            Given(I: tap(keyboard.key("return", isActuallyButton: true)))
+            And(I: see(otherElementsScreen.slider))
             When(I: adjust(otherElementsScreen.slider, to: 1))
             Then(I: adjust(otherElementsScreen.slider, to: 0))
         }
@@ -165,6 +166,94 @@ final class OtherElementsTests: TABTestCase, SystemPreferencesContext {
             And(the: value(of: otherElementsScreen.picker.wheel(0), is: "Hello"))
             When(I: adjust(otherElementsScreen.picker.wheel(0), to: "World"))
             Then(the: value(of: otherElementsScreen.picker.wheel(0), is: "World"))
+        }
+        
+        Scenario("Seeing and interacting with the time picker") {
+            Given(I: scroll(otherElementsScreen, .downwards, until: otherElementsScreen.timePicker, is: .visible))
+            And(I: see(otherElementsScreen.timePicker))
+            And(the: value(of: otherElementsScreen.timePicker.wheel(0), is: "9 o’clock"))
+            When(I: adjust(otherElementsScreen.timePicker.wheel(0), to: "10"))
+            Then(the: value(of: otherElementsScreen.timePicker.wheel(0), is: "10 o’clock"))
+        }
+        
+        Scenario("Interacting with the time picker for minutes") {
+            Given(I: see(otherElementsScreen.timePicker))
+            And(the: value(of: otherElementsScreen.timePicker.wheel(1), is: "41 minutes"))
+            When(I: adjust(otherElementsScreen.timePicker.wheel(1), to: "42"))
+            Then(the: value(of: otherElementsScreen.timePicker.wheel(1), is: "42 minutes"))
+        }
+        
+        Scenario("Interacting with the time picker for period") {
+            Given(I: see(otherElementsScreen.timePicker))
+            And(the: value(of: otherElementsScreen.timePicker.wheel(2), is: "AM"))
+            When(I: adjust(otherElementsScreen.timePicker.wheel(2), to: "PM"))
+            Then(the: value(of: otherElementsScreen.timePicker.wheel(2), is: "PM"))
+        }
+        
+        Scenario("Seeing and interacting with the date picker") {
+            Given(I: scroll(otherElementsScreen, .downwards, until: otherElementsScreen.datePicker, is: .visible))
+            And(I: see(otherElementsScreen.datePicker))
+            And(the: value(of: otherElementsScreen.datePicker.wheel(0), is: "January"))
+            When(I: adjust(otherElementsScreen.datePicker.wheel(0), to: "February"))
+            Then(the: value(of: otherElementsScreen.datePicker.wheel(0), is: "February"))
+        }
+        
+        Scenario("Interacting with the date picker for day") {
+            Given(I: see(otherElementsScreen.datePicker))
+            And(the: value(of: otherElementsScreen.datePicker.wheel(1), is: "9"))
+            When(I: adjust(otherElementsScreen.datePicker.wheel(1), to: "10"))
+            Then(the: value(of: otherElementsScreen.datePicker.wheel(1), is: "10"))
+        }
+        
+        Scenario("Interacting with the date picker for year") {
+            Given(I: see(otherElementsScreen.datePicker))
+            And(the: value(of: otherElementsScreen.datePicker.wheel(2), is: "2007"))
+            When(I: adjust(otherElementsScreen.datePicker.wheel(2), to: "2020"))
+            Then(the: value(of: otherElementsScreen.datePicker.wheel(2), is: "2020"))
+        }
+        
+        Scenario("Seeing and interacting with the date time picker") {
+            Given(I: scroll(otherElementsScreen, .downwards, until: otherElementsScreen.dateTimePicker, is: .visible))
+            And(I: see(otherElementsScreen.datePicker))
+            And(the: value(of: otherElementsScreen.dateTimePicker.wheel(0), is: "Tue, Jan 9"))
+            When(I: adjust(otherElementsScreen.dateTimePicker.wheel(0), to: "Jan 10"))
+            Then(the: value(of: otherElementsScreen.dateTimePicker.wheel(0), is: "Wed, Jan 10"))
+        }
+        
+        Scenario("Interacting with the date time picker for hour") {
+            Given(I: see(otherElementsScreen.dateTimePicker))
+            And(the: value(of: otherElementsScreen.dateTimePicker.wheel(1), is: "9 o’clock"))
+            When(I: adjust(otherElementsScreen.dateTimePicker.wheel(1), to: "10"))
+            Then(the: value(of: otherElementsScreen.dateTimePicker.wheel(1), is: "10 o’clock"))
+        }
+        
+        Scenario("Interacting with the date time picker for minute") {
+            Given(I: see(otherElementsScreen.dateTimePicker))
+            And(the: value(of: otherElementsScreen.dateTimePicker.wheel(2), is: "41 minutes"))
+            When(I: adjust(otherElementsScreen.dateTimePicker.wheel(2), to: "42"))
+            Then(the: value(of: otherElementsScreen.dateTimePicker.wheel(2), is: "42 minutes"))
+        }
+        
+        Scenario("Interacting with the date time picker for period") {
+            Given(I: see(otherElementsScreen.dateTimePicker))
+            And(the: value(of: otherElementsScreen.dateTimePicker.wheel(3), is: "AM"))
+            When(I: adjust(otherElementsScreen.dateTimePicker.wheel(3), to: "PM"))
+            Then(the: value(of: otherElementsScreen.dateTimePicker.wheel(3), is: "PM"))
+        }
+
+        Scenario("Seeing and interacting with the count down timer picker") {
+            Given(I: scroll(otherElementsScreen, .from(CGVector(dx: 0.95, dy: 0.8), to: CGVector(dx: 0.95, dy: 0.3)), until: otherElementsScreen.countdownTimerPicker, is: .visible)) // We need to scroll down on the edge of the screen, otherwise it will scroll one of the picker.
+            And(I: see(otherElementsScreen.countdownTimerPicker))
+            And(the: value(of: otherElementsScreen.countdownTimerPicker.wheel(0), is: "0 hours"))
+            When(I: adjust(otherElementsScreen.countdownTimerPicker.wheel(0), to: "1"))
+            Then(the: value(of: otherElementsScreen.countdownTimerPicker.wheel(0), is: "1 hour"))
+        }
+        
+        Scenario("Interacting with the date time picker for hour") {
+            Given(I: see(otherElementsScreen.countdownTimerPicker))
+            And(the: value(of: otherElementsScreen.countdownTimerPicker.wheel(1), is: "1 min"))
+            When(I: adjust(otherElementsScreen.countdownTimerPicker.wheel(1), to: "59"))
+            Then(the: value(of: otherElementsScreen.countdownTimerPicker.wheel(1), is: "59 min"))
         }
     }
     

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ func test_login() {
       - [`Stepper`](#stepper)
       - [`SegmentedControl`](#segmentedcontrol)
       - [`Picker`](#picker)
+      - [`DatePicker`](#datePicker)
       - [`PageIndicator`](#pageindicator)
       - [`WebView`](#webview)
       - [`Image`](#image)
@@ -1116,6 +1117,35 @@ XCTAssertEqual(wheel.value, "The value")
 ```
 
 Since a `Picker`'s `Wheel` also conforms to [`Adjustable`](#adjustable), you can
+adjust the value to another `String`:
+
+```swift
+wheel.adjust(to: "New value")
+```
+
+#### DatePicker
+
+`DatePicker` represents a date picker in the app:
+
+```swift
+let datePicker = DatePicker(id: "MyPicker")
+```
+
+For iOS 13 and under. You don't interact with the picker directly, instead you interact with the wheels
+inside the picker. To interact with a wheel, first ask the picker for it:
+
+```swift
+let wheel = datePicker.wheel(0)
+```
+
+Since a `DatePicker`'s `Wheel` conforms to [`ValueRepresentable`](#valuerepresentable),
+you can get the string value:
+
+```swift
+XCTAssertEqual(wheel.value, "The value")
+```
+
+Since a `DatePicker`'s `Wheel` also conforms to [`Adjustable`](#adjustable), you can
 adjust the value to another `String`:
 
 ```swift

--- a/TABTestKit.xcodeproj/project.pbxproj
+++ b/TABTestKit.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		70D1C4DD24BDEFE70047A2EB /* Image.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D1C4DC24BDEFE70047A2EB /* Image.swift */; };
 		9536C80D2412A7D100D4B362 /* ActivitySheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9536C80C2412A7D100D4B362 /* ActivitySheet.swift */; };
 		957289A72481452C00DBC55D /* Icon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 957289A62481452C00DBC55D /* Icon.swift */; };
+		95AB580024E55DE200016595 /* DatePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95AB57FF24E55DE200016595 /* DatePicker.swift */; };
 		95D471C22397C8C1002BEFCA /* SheetContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95D4716B2397C8C1002BEFCA /* SheetContext.swift */; };
 		95D471C32397C8C1002BEFCA /* BiometricsContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95D4716C2397C8C1002BEFCA /* BiometricsContext.swift */; };
 		95D471C42397C8C1002BEFCA /* NavigationContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95D4716D2397C8C1002BEFCA /* NavigationContext.swift */; };
@@ -86,6 +87,7 @@
 		70D1C4DC24BDEFE70047A2EB /* Image.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Image.swift; sourceTree = "<group>"; };
 		9536C80C2412A7D100D4B362 /* ActivitySheet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivitySheet.swift; sourceTree = "<group>"; };
 		957289A62481452C00DBC55D /* Icon.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Icon.swift; sourceTree = "<group>"; };
+		95AB57FF24E55DE200016595 /* DatePicker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatePicker.swift; sourceTree = "<group>"; };
 		95D471462397C1A9002BEFCA /* TABTestKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TABTestKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		95D4715D2397C8C1002BEFCA /* Biometrics.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Biometrics.h; sourceTree = "<group>"; };
 		95D471652397C8C1002BEFCA /* Biometrics-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "Biometrics-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -265,6 +267,7 @@
 				95D4719A2397C8C1002BEFCA /* Button.swift */,
 				95D4718A2397C8C1002BEFCA /* Cell.swift */,
 				95D471892397C8C1002BEFCA /* CollectionView.swift */,
+				95AB57FF24E55DE200016595 /* DatePicker.swift */,
 				95D4718F2397C8C1002BEFCA /* Header.swift */,
 				957289A62481452C00DBC55D /* Icon.swift */,
 				70D1C4DC24BDEFE70047A2EB /* Image.swift */,
@@ -470,6 +473,7 @@
 				9536C80D2412A7D100D4B362 /* ActivitySheet.swift in Sources */,
 				95D471EC2397C8C1002BEFCA /* SecureTextField.swift in Sources */,
 				95D471FA2397C8C1002BEFCA /* Tappable.swift in Sources */,
+				95AB580024E55DE200016595 /* DatePicker.swift in Sources */,
 				95EB8E57239E4CC4007336E8 /* Step.swift in Sources */,
 				95D471EE2397C8C1002BEFCA /* Button.swift in Sources */,
 				95D471E72397C8C1002BEFCA /* NavBar.swift in Sources */,

--- a/TABTestKit/Classes/Elements/DatePicker.swift
+++ b/TABTestKit/Classes/Elements/DatePicker.swift
@@ -1,0 +1,63 @@
+//
+//  DatePicker.swift
+//  TABTestKit
+//
+//  Created by Roger Tan on 12/08/2020.
+//
+
+import XCTest
+
+/// Represents a DatePicker (UIDatePicker on iOS).
+/// To interact with the wheels you must first
+/// ask the picker for one of it's wheels, by index.
+public struct DatePicker: Element {
+    
+    public let id: String?
+    public let index: Int
+    public let parent: Element
+    public let type: XCUIElement.ElementType = .datePicker
+    
+    /// Returns the number of wheels the picker contains.
+    public var numberOfWheels: Int { return underlyingXCUIElement.pickerWheels.count }
+    
+    public init(id: String, index: Int = 0, parent: Element = App.shared) {
+        self.id = id
+        self.index = index
+        self.parent = parent
+    }
+    
+    /// Returns the wheel for the given index.
+    ///
+    /// - Parameter index: The index (starting at 0) of the wheel you want to retrieve.
+    /// - Returns: The wheel at the provided index.
+    public func wheel(_ index: Int) -> Wheel {
+        return Wheel(index: index, picker: self)
+    }
+    
+}
+
+public extension DatePicker {
+
+    /// Represents a wheel in a UIDatePicker. You can create these yourselves, but it's
+    /// recommended to create a DatePicker instead and ask it for the wheels.
+    struct Wheel: Element, ValueRepresentable, Adjustable {
+
+        public let id: String? = nil
+        public let index: Int
+        public let parent: Element
+        public let type: XCUIElement.ElementType = .pickerWheel
+        public var value: String { return underlyingXCUIElement.value as? String ?? "" }
+
+        public init(index: Int, picker: DatePicker) {
+            self.index = index
+            self.parent = picker
+        }
+
+        public func adjust(to newValue: String) {
+            guard newValue != value else { XCTFatalFail("Date Picker is already in state \(newValue)") }
+            underlyingXCUIElement.adjust(toPickerWheelValue: newValue)
+        }
+
+    }
+
+}


### PR DESCRIPTION
#### What's in this PR?

This PR will add official support of DatePicker element and will resolve issue #55. This will help in future to support the new behaviour of Date Picker in iOS 14. #125 

---

#### Pre-merge checklist

Before merging any PR, please check the following common things that should be done beforehand. These aren't all always required, so just check the box if it doesn't apply.

- [x] **When adding files, make sure they're added to the right target**. If you're adding new files that should be bundled up with Cocoapods etc, they need to be added to the `TABTestKit` target, not `Pods-TABTestKit_Example` etc.
- [x] **Run `pod install` to ensure that the latest changes are in the Example project**. Without this, Carthage might not see the latest changes.
- [x] **Added and updated tests where possible**. This isn't always possible but try wherever you can. The example app contains UI tests to test many of the TABTestKit features.
- [x] **Updated the `CHANGELOG`**. For any changes pending a release, add to the Pending section. For releases, move everything pending to the release section.
- [x] **Updated the `README`**. Add info for any new features, update existing info for anything that's changed or needs extra info.
