### PR TITLE
Chore/upload test result

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,19 +8,24 @@ on:
   push:
     branches: ['*']
 jobs:
-#   test_xcode10_ios12:
-#     name: Run tests on Xcode 10 and iOS 12
-#     runs-on: macOS-latest
+  test_xcode10_ios12:
+    name: Run tests on Xcode 10 and iOS 12
+    runs-on: macOS-latest
 
-#     steps:
-#       - name: Checkout
-#         uses: actions/checkout@v1
-#       - name: Set Xcode version to 10.3
-#         run: sudo xcode-select -switch /Applications/Xcode_10.3.app
-#       - name: Build for testing
-#         run: xcodebuild build-for-testing -workspace Example/TABTestKit.xcworkspace -scheme TABTestKit-Example -destination 'platform=iOS Simulator,name=iPhone Xs,OS=12.4'
-#       - name: Test on iPhone Xs
-#         run: xcodebuild test-without-building -workspace Example/TABTestKit.xcworkspace -scheme TABTestKit-Example -destination 'platform=iOS Simulator,name=iPhone Xs,OS=12.4'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Set Xcode version to 10.3
+        run: sudo xcode-select -switch /Applications/Xcode_10.3.app
+      - name: Build for testing
+        run: xcodebuild build-for-testing -workspace Example/TABTestKit.xcworkspace -scheme TABTestKit-Example -destination 'platform=iOS Simulator,name=iPhone Xs,OS=12.4'
+      - name: Test on iPhone Xs
+        run: xcodebuild test-without-building -workspace Example/TABTestKit.xcworkspace -scheme TABTestKit-Example -destination 'platform=iOS Simulator,name=iPhone Xs,OS=12.4'
+      - name: Archive tests results
+        uses: actions/upload-artifact@v2
+        with:
+          name: Test-TABTestKit-Xcode10-iOS12.xcresult
+          path: /Users/runner/Library/Developer/Xcode/DerivedData/*/Logs/Test/*.xcresult
 
   test_xcode11_ios13:
     name: Run tests on Xcode 11 and iOS 13
@@ -38,50 +43,49 @@ jobs:
       - name: Archive tests results
         uses: actions/upload-artifact@v2
         with:
-          name: tests results
-          path: '/Users/runner/Library/Developer/Xcode/DerivedData/**/Test-TABTestKit-*.xcresult'
+          name: Test-TABTestKit-Xcode11-iOS13.xcresult
+          path: /Users/runner/Library/Developer/Xcode/DerivedData/*/Logs/Test/*.xcresult
 
+  build_spm:
+    name: Ensure Swift Package Manager builds
+    runs-on: macOS-latest
 
-#   build_spm:
-#     name: Ensure Swift Package Manager builds
-#     runs-on: macOS-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Set Xcode version to 11.6
+        run: sudo xcode-select -switch /Applications/Xcode_11.6.app
+      - name: Build Swift Package Manager
+        run: xcodebuild -workspace package.xcworkspace -scheme TABTestKit -destination 'platform=iOS Simulator,name=iPhone 11,OS=13.6'
 
-#     steps:
-#       - name: Checkout
-#         uses: actions/checkout@v1
-#       - name: Set Xcode version to 11.6
-#         run: sudo xcode-select -switch /Applications/Xcode_11.6.app
-#       - name: Build Swift Package Manager
-#         run: xcodebuild -workspace package.xcworkspace -scheme TABTestKit -destination 'platform=iOS Simulator,name=iPhone 11,OS=13.6'
+  build_carthage:
+    name: Ensure Carthage builds
+    runs-on: macOS-latest
 
-#   build_carthage:
-#     name: Ensure Carthage builds
-#     runs-on: macOS-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Set Xcode version to 10.3
+        run: sudo xcode-select -switch /Applications/Xcode_10.3.app
+      - name: Build Carthage
+        run: carthage build --archive
+      - name: Set Xcode version to 11.6
+        run: sudo xcode-select -switch /Applications/Xcode_11.6.app
+      - name: Build Carthage
+        run: carthage build --archive
 
-#     steps:
-#       - name: Checkout
-#         uses: actions/checkout@v1
-#       - name: Set Xcode version to 10.3
-#         run: sudo xcode-select -switch /Applications/Xcode_10.3.app
-#       - name: Build Carthage
-#         run: carthage build --archive
-#       - name: Set Xcode version to 11.6
-#         run: sudo xcode-select -switch /Applications/Xcode_11.6.app
-#       - name: Build Carthage
-#         run: carthage build --archive
+  build_cocoapods:
+    name: Ensure Cocoapods builds
+    runs-on: macOS-latest
 
-#   build_cocoapods:
-#     name: Ensure Cocoapods builds
-#     runs-on: macOS-latest
-
-#     steps:
-#       - name: Checkout
-#         uses: actions/checkout@v1
-#       - name: Set Xcode version to 10.3
-#         run: sudo xcode-select -switch /Applications/Xcode_10.3.app
-#       - name: Build Cocoapods
-#         run: pod lib lint --verbose
-#       - name: Set Xcode version to 11.6
-#         run: sudo xcode-select -switch /Applications/Xcode_11.6.app
-#       - name: Build Cocoapods
-#         run: pod lib lint --verbose
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Set Xcode version to 10.3
+        run: sudo xcode-select -switch /Applications/Xcode_10.3.app
+      - name: Build Cocoapods
+        run: pod lib lint --verbose
+      - name: Set Xcode version to 11.6
+        run: sudo xcode-select -switch /Applications/Xcode_11.6.app
+      - name: Build Cocoapods
+        run: pod lib lint --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,7 @@ on:
   workflow_dispatch: # This allows you to manually run the workflow from GitHub's web UI
   pull_request:
     branches: [ '*' ] # This means this workflow will run when any PR is created or any changes are pushed to a PR, on any branch
-  push:
-    branches: ['*']
+
 jobs:
   test_xcode10_ios12:
     name: Run tests on Xcode 10 and iOS 12

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Set Xcode version to 10.3
         run: sudo xcode-select -switch /Applications/Xcode_10.3.app
       - name: Build for testing
@@ -21,6 +21,7 @@ jobs:
       - name: Test on iPhone Xs
         run: xcodebuild test-without-building -workspace Example/TABTestKit.xcworkspace -scheme TABTestKit-Example -destination 'platform=iOS Simulator,name=iPhone Xs,OS=12.4'
       - name: Archive tests results
+        if: ${{ failure() }}
         uses: actions/upload-artifact@v2
         with:
           name: Test-TABTestKit-Xcode10-iOS12.xcresult
@@ -32,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Set Xcode version to 11.6
         run: sudo xcode-select -switch /Applications/Xcode_11.6.app
       - name: Build for testing
@@ -40,6 +41,7 @@ jobs:
       - name: Test on iPhone 11
         run: xcodebuild test-without-building -workspace Example/TABTestKit.xcworkspace -scheme TABTestKit-Example -destination 'platform=iOS Simulator,name=iPhone 11,OS=13.6'
       - name: Archive tests results
+        if: ${{ failure() }}
         uses: actions/upload-artifact@v2
         with:
           name: Test-TABTestKit-Xcode11-iOS13.xcresult

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,21 +5,22 @@ on:
   workflow_dispatch: # This allows you to manually run the workflow from GitHub's web UI
   pull_request:
     branches: [ '*' ] # This means this workflow will run when any PR is created or any changes are pushed to a PR, on any branch
-
+  push:
+    branches: ['*']
 jobs:
-  test_xcode10_ios12:
-    name: Run tests on Xcode 10 and iOS 12
-    runs-on: macOS-latest
+#   test_xcode10_ios12:
+#     name: Run tests on Xcode 10 and iOS 12
+#     runs-on: macOS-latest
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v1
-      - name: Set Xcode version to 10.3
-        run: sudo xcode-select -switch /Applications/Xcode_10.3.app
-      - name: Build for testing
-        run: xcodebuild build-for-testing -workspace Example/TABTestKit.xcworkspace -scheme TABTestKit-Example -destination 'platform=iOS Simulator,name=iPhone Xs,OS=12.4'
-      - name: Test on iPhone Xs
-        run: xcodebuild test-without-building -workspace Example/TABTestKit.xcworkspace -scheme TABTestKit-Example -destination 'platform=iOS Simulator,name=iPhone Xs,OS=12.4'
+#     steps:
+#       - name: Checkout
+#         uses: actions/checkout@v1
+#       - name: Set Xcode version to 10.3
+#         run: sudo xcode-select -switch /Applications/Xcode_10.3.app
+#       - name: Build for testing
+#         run: xcodebuild build-for-testing -workspace Example/TABTestKit.xcworkspace -scheme TABTestKit-Example -destination 'platform=iOS Simulator,name=iPhone Xs,OS=12.4'
+#       - name: Test on iPhone Xs
+#         run: xcodebuild test-without-building -workspace Example/TABTestKit.xcworkspace -scheme TABTestKit-Example -destination 'platform=iOS Simulator,name=iPhone Xs,OS=12.4'
 
   test_xcode11_ios13:
     name: Run tests on Xcode 11 and iOS 13
@@ -34,47 +35,53 @@ jobs:
         run: xcodebuild build-for-testing -workspace Example/TABTestKit.xcworkspace -scheme TABTestKit-Example -destination 'platform=iOS Simulator,name=iPhone 11,OS=13.6'
       - name: Test on iPhone 11
         run: xcodebuild test-without-building -workspace Example/TABTestKit.xcworkspace -scheme TABTestKit-Example -destination 'platform=iOS Simulator,name=iPhone 11,OS=13.6'
+      - name: Archive tests results
+        uses: actions/upload-artifact@v2
+        with:
+          name: tests results
+          path: '/Users/runner/Library/Developer/Xcode/DerivedData/**/Test-TABTestKit-*.xcresult'
 
-  build_spm:
-    name: Ensure Swift Package Manager builds
-    runs-on: macOS-latest
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v1
-      - name: Set Xcode version to 11.6
-        run: sudo xcode-select -switch /Applications/Xcode_11.6.app
-      - name: Build Swift Package Manager
-        run: xcodebuild -workspace package.xcworkspace -scheme TABTestKit -destination 'platform=iOS Simulator,name=iPhone 11,OS=13.6'
+#   build_spm:
+#     name: Ensure Swift Package Manager builds
+#     runs-on: macOS-latest
 
-  build_carthage:
-    name: Ensure Carthage builds
-    runs-on: macOS-latest
+#     steps:
+#       - name: Checkout
+#         uses: actions/checkout@v1
+#       - name: Set Xcode version to 11.6
+#         run: sudo xcode-select -switch /Applications/Xcode_11.6.app
+#       - name: Build Swift Package Manager
+#         run: xcodebuild -workspace package.xcworkspace -scheme TABTestKit -destination 'platform=iOS Simulator,name=iPhone 11,OS=13.6'
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v1
-      - name: Set Xcode version to 10.3
-        run: sudo xcode-select -switch /Applications/Xcode_10.3.app
-      - name: Build Carthage
-        run: carthage build --archive
-      - name: Set Xcode version to 11.6
-        run: sudo xcode-select -switch /Applications/Xcode_11.6.app
-      - name: Build Carthage
-        run: carthage build --archive
+#   build_carthage:
+#     name: Ensure Carthage builds
+#     runs-on: macOS-latest
 
-  build_cocoapods:
-    name: Ensure Cocoapods builds
-    runs-on: macOS-latest
+#     steps:
+#       - name: Checkout
+#         uses: actions/checkout@v1
+#       - name: Set Xcode version to 10.3
+#         run: sudo xcode-select -switch /Applications/Xcode_10.3.app
+#       - name: Build Carthage
+#         run: carthage build --archive
+#       - name: Set Xcode version to 11.6
+#         run: sudo xcode-select -switch /Applications/Xcode_11.6.app
+#       - name: Build Carthage
+#         run: carthage build --archive
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v1
-      - name: Set Xcode version to 10.3
-        run: sudo xcode-select -switch /Applications/Xcode_10.3.app
-      - name: Build Cocoapods
-        run: pod lib lint --verbose
-      - name: Set Xcode version to 11.6
-        run: sudo xcode-select -switch /Applications/Xcode_11.6.app
-      - name: Build Cocoapods
-        run: pod lib lint --verbose
+#   build_cocoapods:
+#     name: Ensure Cocoapods builds
+#     runs-on: macOS-latest
+
+#     steps:
+#       - name: Checkout
+#         uses: actions/checkout@v1
+#       - name: Set Xcode version to 10.3
+#         run: sudo xcode-select -switch /Applications/Xcode_10.3.app
+#       - name: Build Cocoapods
+#         run: pod lib lint --verbose
+#       - name: Set Xcode version to 11.6
+#         run: sudo xcode-select -switch /Applications/Xcode_11.6.app
+#       - name: Build Cocoapods
+#         run: pod lib lint --verbose

--- a/Example/TABTestKit_ExampleUITests/OtherElementsTests.swift
+++ b/Example/TABTestKit_ExampleUITests/OtherElementsTests.swift
@@ -133,7 +133,7 @@ final class OtherElementsTests: TABTestCase, SystemPreferencesContext {
         Scenario("Seeing and interacting with the switch") {
             Given(I: see(otherElementsScreen.toggle))
             And(the: value(of: otherElementsScreen.toggle, is: .on))
-            Then(I: adjust(otherElementsScreen.toggle, to: .off))
+//             Then(I: adjust(otherElementsScreen.toggle, to: .off))
             And(the: value(of: otherElementsScreen.toggle, is: .off))
         }
         

--- a/Example/TABTestKit_ExampleUITests/OtherElementsTests.swift
+++ b/Example/TABTestKit_ExampleUITests/OtherElementsTests.swift
@@ -133,7 +133,7 @@ final class OtherElementsTests: TABTestCase, SystemPreferencesContext {
         Scenario("Seeing and interacting with the switch") {
             Given(I: see(otherElementsScreen.toggle))
             And(the: value(of: otherElementsScreen.toggle, is: .on))
-//             Then(I: adjust(otherElementsScreen.toggle, to: .off))
+            Then(I: adjust(otherElementsScreen.toggle, to: .off))
             And(the: value(of: otherElementsScreen.toggle, is: .off))
         }
         


### PR DESCRIPTION
#### What's in this PR?

This PR will give the option to upload the xcresult as an artefact in case of failure. An example of a job failure with artefacts can be found [here](https://github.com/theappbusiness/TABTestKit/actions/runs/208435993) 

---

#### Pre-merge checklist

Before merging any PR, please check the following common things that should be done beforehand. These aren't all always required, so just check the box if it doesn't apply.

- [x] **When adding files, make sure they're added to the right target**. If you're adding new files that should be bundled up with Cocoapods etc, they need to be added to the `TABTestKit` target, not `Pods-TABTestKit_Example` etc.
- [x] **Run `pod install` to ensure that the latest changes are in the Example project**. Without this, Carthage might not see the latest changes.
- [x] **Added and updated tests where possible**. This isn't always possible but try wherever you can. The example app contains UI tests to test many of the TABTestKit features.
- [x] **Updated the `CHANGELOG`**. For any changes pending a release, add to the Pending section. For releases, move everything pending to the release section.
- [x] **Updated the `README`**. Add info for any new features, update existing info for anything that's changed or needs extra info.
